### PR TITLE
Fix typo in megacmdshell error message

### DIFF
--- a/src/megacmdshell/megacmdshellcommunications.cpp
+++ b/src/megacmdshell/megacmdshellcommunications.cpp
@@ -440,7 +440,7 @@ int MegaCmdShellCommunications::createSocket(int number, bool initializeserver, 
                     {
                         if (errno == 2 )
                         {
-                            cerr << "Couln't initiate MEGAcmd server: executable not found: " << executable << endl;
+                            cerr << "Couldn't initiate MEGAcmd server: executable not found: " << executable << endl;
 
                         }
                         else


### PR DESCRIPTION
```
[user@linux megacmd]$ ./mega-exec ls
[Initiating server in background. Log: /home/user/.megaCmd/megacmdserver.log]
Couln't initiate MEGAcmd server: executable not found: mega-cmd-server
```