### PR TITLE
QNAP NAS build (x31 platform)

### DIFF
--- a/build/QNAP_NAS/README.md
+++ b/build/QNAP_NAS/README.md
@@ -14,13 +14,16 @@ This example is for ARM, x86 and x86_64 will be similar.
 Cross compiling machine requirements:
   - **Most or all commands need to be run as 'sudo'**.  
   - dos2unix
-  - cross compiler from QNAP: install by following QNAP instructions to unzip cross-project-arm-20110901.tar.gz in your `/opt/cross-project` folder.
+  - cross compiler from QNAP: install by following QNAP instructions to unzip one of these (available from qnap) in your `/opt/cross-project` folder 
+    - `cross-project-arm-20110901.tar.gz` (for x19 platform) or 
+    - `TS-x31+_cross-project-arm_al.20150909.tar.gz` (for x31+ platform)
 
-Then copy or git clone the MEGAcmd project to /opt/cross-project/arm/marvell/arm-none-linux-gnueabi/libc/marvell-f/src/MEGAcmd.  The sdk must be copied or cloned to the 'sdk' subfolder of that.
+Then copy or git clone the MEGAcmd project to /opt/cross-project/qnap/MEGAcmd.  The sdk must be copied or cloned to the 'sdk' subfolder of that.
 
 From the MEGAcmd folder, execute:
-`./build/QNAP/build`
-which will result in the binaries and scripts ending up in the MEGAcmd/install folder.
+`./build/QNAP/build-marvell`  (for x19 platform)
+`./build/QNAP/build-marvell`  (for x31+ platform)
+which will result in the binaries and scripts ending up in the MEGAcmd/install folder and being copied to the megacmdpkg folder ready to build the package.
 
 
 # Building a QNAP package
@@ -29,8 +32,7 @@ This must be done on a QNAP NAS as it requires their QDK package.  Download QDK_
 
 Next, use `scp` or a similar tool to copy the MEGAcmd/build/QNAP_NAS/megacmdpkg folder to the NAS, followed by the contents of the MEGAcmd/install folder:
 `scp -r build/QNAP_NAS/megacmdpkg admin@10.12.0.248:/share/CACHEDEV1_DATA/.qpkg/QDK/`
-`scp -r install/* admin@10.12.0.248:/share/CACHEDEV1_DATA/.qpkg/QDK/megacmdpkg/arm-x41`
 
-On the NAS, using ssh or similar, edit the qpkg.cfg to adjust version numbers etc and then run the `qbuild` command from the megacmdpkg folder.   The package will be built and put in the 'build' subfolder.
+On the NAS, using ssh or similar, run the `qbuild` command from the megacmdpkg folder.   The package will be built and put in the 'build' subfolder.
 
 

--- a/build/QNAP_NAS/build-linaro
+++ b/build/QNAP_NAS/build-linaro
@@ -1,0 +1,144 @@
+#!/bin/bash
+# run this from the MEGAcmd folder
+# but first set up the environment per the PDF and tar files at https://sourceforge.net/projects/qosgpl/files/QNAP%20NAS%20Tool%20Chains/
+# and put the MEGAcmd tree at /opt/cross-project/qnap/
+# this first sample build uses the arm cross compile toolchain, testing on the TS-228
+
+#prerequisites:
+#  - qnap installed cross compiler from http://download.qnap.com/dev/Toolchain/TS-x31%2B_cross-project-arm_al.20150909.tar.gz
+#     (unzipped to /opt/)
+#  - 32 bit libz, eg this works for ubuntu 16.04: sudo apt-get install zlib1g:i386
+
+
+export PROJECT=arm-linux-gnueabihf
+export PRJROOT=/opt/cross-project/arm/linaro
+export ARCH=arm
+export TARGET=arm-linux-gnueabihf
+export CROSS_COMPILE=${TARGET}-
+export TARGET_PREFIX=${PRJROOT}/${PROJECT}/libc
+export TARGET_PREFIX=${PRJROOT}/${PROJECT}/libc
+export SYS_TARGET_PREFIX=${PRJROOT}/${PROJECT}/libc
+export PATH=${PRJROOT}/bin:${PATH}:/usr/sbin:/sbin
+
+
+export MEGA_CMD_DIR=/opt/cross-project/qnap/MEGAcmd
+
+#export PATH=/opt/cross-project/arm/linaro/arm-linux-gnueabihf/libc/usr/lib/:/opt/cross-project/arm/linaro/bin:$PATH
+#export LD_LIBRARY_PATH=/opt/cross-project/arm/linaro/arm-linux-gnueabihf/libc/usr/lib:$LD_LIBRARY_PATH
+
+export MACHINE=armada38x
+export CUSTOM_CONFIG_ARGS="--host=${TARGET} --disable-dependency-tracking"
+
+export CC=${CROSS_COMPILE}gcc
+export CXX=${CROSS_COMPILE}g++
+export LD=${CROSS_COMPILE}ld
+export CFLAGS="$CFLAGS -fPIC -fexceptions -fvisibility=hidden -fsigned-char"
+export CPPFLAGS="-DNDEBUG"
+export CXXFLAGS="$CXXFLAGS $CFLAGS -DNDEBUG"
+export AR=${CROSS_COMPILE}ar
+export NM=${CROSS_COMPILE}nm
+export STRIP=${CROSS_COMPILE}strip
+export RANLIB=${CROSS_COMPILE}ranlib
+export OBJDUMP=${CROSS_COMPILE}objdump
+export LDFLAGS=
+export ConfigOpt=
+#export ARCH=$ARCH
+export ToolChainSysRoot=$SYS_TARGET_PREFIX
+export SysRootPrefix=$SYS_TARGET_PREFIX
+export SysRootInclude=$SYS_TARGET_PREFIX/include
+export SysRootLib=$SYS_TARGET_PREFIX/lib
+
+export CROSS_COMPILE=
+
+export AUTOMAKE_OPTIONS="no-dependencies"
+
+
+echo ---------- env set up --------------------
+env | sort
+echo ---------- env set up --------------------
+
+#fix any utf-8 w/ BOM files that the compiler can't handle
+cd $MEGA_CMD_DIR
+find src -name "*.h" | xargs dos2unix
+find src -name "*.c" | xargs dos2unix
+find src -name "*.cpp" | xargs dos2unix
+find sdk/include -name "*.h" | xargs dos2unix
+find sdk/src -name "*.c" | xargs dos2unix
+find sdk/src -name "*.cpp" | xargs dos2unix
+
+
+cd $MEGA_CMD_DIR/sdk
+pwd
+
+mkdir -p norecurse
+mv norecurse/* .
+
+./contrib/build_sdk.sh -a -e -g -I -n -q -R -S -X -C"$CUSTOM_CONFIG_ARGS" -O linux-generic32 -0 2>&1 | tee $MEGA_CMD_DIR/mybuildlogs-sdkbuild.out
+
+if ! [ -e src/libmega.a ] ; then
+    echo "libtool could not link it so we do it ourselves. Including Zen and MediaInfo somehow reference a nonexistent path /home/slava in the Synology libtool libraries. If we left those out it would make the lib ok."
+    echo "we make the lib using $AR directly, with and output the same name src/libmega.la that satisfies the configure script for MEGAcmd."
+    rm -f src/libmega.la
+    $AR -rcs ./src/libmega.a `find src -name "*.o"` `find sdk_build -name "*.a"`
+    cp ./src/libmega.a ./src/libmega.la
+fi
+
+if ! [ -e ./sdk_build/install/lib/libmega.a ] ; then
+    cp ./src/libmega* ./sdk_build/install/lib/
+fi
+
+if ! [ -e ./sdk_build/install/lib/libmega.a ] ; then
+   echo "SDK build failed"
+   exit 1
+fi
+
+mv ./Makefile* norecurse/
+mv ./config* norecurse/
+cd ..
+
+echo -------------------------------------------------------- sdk end --------------------------------------
+
+
+echo about to build megacmd ---------------------------
+
+sh autogen.sh 2>&1 | tee $MEGA_CMD_DIR/mybuildlogs-autogen2.out
+./configure SUBDIRS="" --enable-static --with-cryptopp --with-readline=/opt/cross-project/arm/marvell/arm-none-linux-gnueabi/libc/marvell-f/src/MEGAcmd/sdk/sdk_build/install/include/ \
+            $CUSTOM_CONFIG_ARGS  2>&1 | tee $MEGA_CMD_DIR/mybuildlogs-configure2.out 
+
+
+export INCLUDES="-I$MEGA_CMD_DIR/sdk/sdk_build/install/include -I$MEGA_CMD_DIR/sdk/include/ -I$MEGA_CMD_DIR/include/mega/posix"
+#somehow autotools is determined to have WIN32 defined
+#make SUBDIRS='' 2>&1 | tee $MEGA_CMD_DIR/mybuildlogs-make2.out
+
+rm -f mega-cmd-server
+rm -f mega-cmd
+rm -f mega-cmd-exec
+
+$CXX $CXXFLAGS src/megacmd.cpp src/comunicationsmanager.cpp         src/megacmdutils.cpp src/configurationmanager.cpp         src/megacmdlogger.cpp src/megacmdsandbox.cpp src/listeners.cpp         src/megacmdexecuter.cpp         src/comunicationsmanagerportsockets.cpp src/comunicationsmanagerfilesockets.cpp -Isdk/include -Isdk/include/mega/posix -Isdk/sdk_build/install/include  sdk/sdk_build/install/lib/libmega.a sdk/sdk_build/install/lib/libcryptopp.a    sdk/sdk_build/install/lib/libcurl.a sdk/sdk_build/install/lib/libcares.a sdk/sdk_build/install/lib/libssl.a sdk/sdk_build/install/lib/libcrypto.a  sdk/sdk_build/install/lib/libsqlite3.a sdk/sdk_build/install/lib/libfreeimage.a sdk/sdk_build/install/lib/libmediainfo.a sdk/sdk_build/install/lib/libzen.a -lpthread -ldl -lrt sdk/sdk_build/install/lib/libz.a -o mega-cmd-server
+
+$CXX $CXXFLAGS src/megacmdshell/*.cpp -Isdk/include -Isdk/include/mega/posix -Isdk/sdk_build/install/include  sdk/sdk_build/install/lib/libmega.a sdk/sdk_build/install/lib/libcryptopp.a    sdk/sdk_build/install/lib/libcurl.a sdk/sdk_build/install/lib/libcares.a sdk/sdk_build/install/lib/libssl.a sdk/sdk_build/install/lib/libcrypto.a  sdk/sdk_build/install/lib/libsqlite3.a -lpthread -ldl -lrt sdk/sdk_build/install/lib/libz.a ./sdk/sdk_build/install/lib/libreadline.a ./sdk/sdk_build/install/lib/libtermcap.a -o mega-cmd
+
+$CXX $CXXFLAGS  src/client/*.cpp src/megacmdshell/megacmdshellcommunications.cpp -Isdk/include -Isdk/include/mega/posix -Isdk/sdk_build/install/include  sdk/sdk_build/install/lib/libmega.a sdk/sdk_build/install/lib/libcryptopp.a    sdk/sdk_build/install/lib/libcurl.a sdk/sdk_build/install/lib/libcares.a sdk/sdk_build/install/lib/libssl.a sdk/sdk_build/install/lib/libcrypto.a  sdk/sdk_build/install/lib/libsqlite3.a -lpthread -ldl -lrt sdk/sdk_build/install/lib/libz.a -o mega-exec
+
+echo "outputs should be 3 files: mega-cmd mega-cmd-server mega-exec.  ls output: "
+ls mega-cmd mega-cmd-server mega-exec
+
+if [ -e mega-cmd ] && [ -e mega-cmd-server ] && [ -e mega-exec ] ; then
+
+    mkdir -p install
+    cp src/client/mega-* install/
+    cp mega-cmd mega-exec mega-cmd-server install/
+
+    mkdir -p build/QNAP_NAS/megacmdpkg/arm-x41
+    cp install/* build/QNAP_NAS/megacmdpkg/arm-x41
+
+    MAJOR=`sed -n -e 's/.*MAJOR_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
+    MINOR=`sed -n -e 's/.*MINOR_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
+    MICRO=`sed -n -e 's/.*MICRO_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
+    MEGACMD_VERSION="\"$MAJOR.$MINOR.$MICRO\""
+    sudo sed -i build/QNAP_NAS/megacmdpkg/qpkg.cfg -e "s/^QPKG_VER=.*/QPKG_VER=$MEGACMD_VERSION/"
+else
+    echo "Build failed"
+    exit 1
+fi
+

--- a/build/QNAP_NAS/build-marvell
+++ b/build/QNAP_NAS/build-marvell
@@ -1,27 +1,26 @@
 #!/bin/bash
 # run this from the MEGAcmd folder
 # but first set up the environment per the PDF and tar files at https://sourceforge.net/projects/qosgpl/files/QNAP%20NAS%20Tool%20Chains/
-# and put the MEGAcmd tree at /opt/cross-project/arm/marvell/arm-none-linux-gnueabi/libc/marvell-f/src/
+# and put the MEGAcmd tree at /opt/cross-project/qnap/
 # this first sample build uses the arm cross compile toolchain, testing on the TS-228
+
+#dependencies
+# - qnap cross compiler from unzipping cross-project-arm-20110901.tar.gz per the PDF instructions.  This corresponds to the qnap arm-x19 platform 
+# - dox2unix
 
 . /opt/cross-project/arm/marvell/arm-glibc-2.5.env
 
-export MEGA_CMD_DIR=$TARGET_PREFIX/src/MEGAcmd
+export MEGA_CMD_DIR=/opt/cross-project/qnap/MEGAcmd
 
 export PATH=/opt/cross-project/arm/marvell/arm-none-linux-gnueabi/libc/marvell-f/usr/share:/opt/cross-project/arm/marvell/bin:$PATH
 
 export MACHINE=armada38x
 export CUSTOM_CONFIG_ARGS="--host=arm-none-linux-gnueabi --disable-dependency-tracking"
-#export CUSTOM_CONFIG_ARGS="linux-generic32 --host=arm-none-linux-gnueabi"
-#export CUSTOM_CONFIG_ARGS="-m32 linux-generic32 "
-#export CUSTOM_CONFIG_ARGS="-m32 linux-generic32 --cross-compile-prefix=$CROSS_COMPILE"
-#export CUSTOM_CONFIG_ARGS="-march=armv7-a --host=arm-none-linux-gnueabi --target=arm-none-linux-gnueabi --build=i686-pc-linux" 
-#export AM_LIBTOOLFLAGS=" --tag=CXX "
 
 export CC=${CROSS_COMPILE}gcc
 export CXX=${CROSS_COMPILE}g++
 export LD=${CROSS_COMPILE}ld
-export CFLAGS="$CFLAGS -O3 -fPIC -fexceptions -fvisibility=hidden -fsigned-char -DNDEBUG"
+export CFLAGS="$CFLAGS -fPIC -fexceptions -fvisibility=hidden -fsigned-char"
 export CPPFLAGS="-DNDEBUG"
 export CXXFLAGS="$CXXFLAGS $CFLAGS -DNDEBUG"
 export AR=${CROSS_COMPILE}ar
@@ -31,7 +30,6 @@ export RANLIB=${CROSS_COMPILE}ranlib
 export OBJDUMP=${CROSS_COMPILE}objdump
 export LDFLAGS=
 export ConfigOpt=
-#export ARCH=$ARCH
 export ToolChainSysRoot=$SYS_TARGET_PREFIX
 export SysRootPrefix=$SYS_TARGET_PREFIX
 export SysRootInclude=$SYS_TARGET_PREFIX/include
@@ -67,16 +65,19 @@ echo executing ./contrib/build_sdk.sh -a -e -f -g -I -q -X -C "$CUSTOM_CONFIG_AR
 #ultimately after overcoming many build challenges, we still can't build freeimage, as it turns out it uses __sync builtins, but they fail to link.  Hence the -f
 ./contrib/build_sdk.sh -a -e -g -f -I -n -q -R -X -C"$CUSTOM_CONFIG_ARGS" -O linux-generic32 -0 2>&1 | tee $MEGA_CMD_DIR/mybuildlogs-sdkbuild.out
 
-if ! [ -e src/libmega.la ] ; then
+if ! [ -e src/libmega.a ] ; then
     echo "libtool could not link it so we do it ourselves. Including Zen and MediaInfo somehow reference a nonexistent path /home/slava in the Synology libtool libraries. If we left those out it would make the lib ok."
     echo "we make the lib using $AR directly, with and output the same name src/libmega.la that satisfies the configure script for MEGAcmd."
     rm -f src/libmega.la
-    $AR -rcs ./src/libmega.la `find src -name "*.o"` `find sdk_build -name "*.a"`
+    $AR -rcs ./src/libmega.a `find src -name "*.o"` `find sdk_build -name "*.a"`
     cp ./src/libmega.a ./src/libmega.la
+fi
+
+if ! [ -e ./sdk_build/install/lib/libmega.a ] ; then
     cp ./src/libmega* ./sdk_build/install/lib/
 fi
 
-if ! [ -e ./src/libmega.la ] ; then
+if ! [ -e ./sdk_build/install/lib/libmega.a ] ; then
    echo "SDK build failed"
    exit 1
 fi
@@ -112,15 +113,22 @@ $CXX $CXXFLAGS  src/client/*.cpp src/megacmdshell/megacmdshellcommunications.cpp
 echo "outputs should be 3 files: mega-cmd mega-cmd-server mega-exec.  ls output: "
 ls mega-cmd mega-cmd-server mega-exec
 
-mkdir -p install
-cp src/client/mega-* install/
-cp mega-cmd mega-exec mega-cmd-server install/
+if [ -e mega-cmd ] && [ -e mega-cmd-server ] && [ -e mega-exec ] ; then
 
-cp install/* build/QNAP_NAS/megacmdpkg/arm-x41
+    mkdir -p install
+    cp src/client/mega-* install/
+    cp mega-cmd mega-exec mega-cmd-server install/
 
-MAJOR=`sed -n -e 's/.*MAJOR_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
-MINOR=`sed -n -e 's/.*MINOR_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
-MICRO=`sed -n -e 's/.*MICRO_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
-MEGACMD_VERSION="\"$MAJOR.$MINOR.$MICRO\""
-sudo sed -i build/QNAP_NAS/megacmdpkg/qpkg.cfg -e "s/^QPKG_VER=.*/QPKG_VER=$MEGACMD_VERSION/"
+    mkdir -p build/QNAP_NAS/megacmdpkg/arm-x19
+    cp install/* build/QNAP_NAS/megacmdpkg/arm-x19
+
+    MAJOR=`sed -n -e 's/.*MAJOR_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
+    MINOR=`sed -n -e 's/.*MINOR_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
+    MICRO=`sed -n -e 's/.*MICRO_VERSION \([0-9]*\).*/\1/p' < src/megacmdversion.h`
+    MEGACMD_VERSION="\"$MAJOR.$MINOR.$MICRO\""
+    sudo sed -i build/QNAP_NAS/megacmdpkg/qpkg.cfg -e "s/^QPKG_VER=.*/QPKG_VER=$MEGACMD_VERSION/"
+else
+    echo "Build failed"
+    exit 1
+fi
 

--- a/build/QNAP_NAS/megacmdpkg/qpkg.cfg
+++ b/build/QNAP_NAS/megacmdpkg/qpkg.cfg
@@ -29,21 +29,21 @@ QPKG_SERVICE_PROGRAM="MEGAcmd.sh"
 # Location of file with running service's PID
 #QPKG_SERVICE_PIDFILE=""
 # Relative path to web interface
-#QPKG_WEBUI=""
+QPKG_WEBUI="/MEGAcmd/"
 # Port number for the web interface.
-#QPKG_WEB_PORT=""
+QPKG_WEB_PORT="80"
 # Port number for the SSL web interface.
-#QPKG_WEB_SSL_PORT=""
+QPKG_WEB_SSL_PORT="8081"
 
 # Use QTS HTTP Proxy and set Proxy_Path in the qpkg.conf. 
 # When the QPKG has its own HTTP service port, and want clients to connect via QTS HTTP port (default 8080).
 # Usually use this option when the QPKG need to connect via myQNAPcloud service.
-#QPKG_USE_PROXY="1"
+QPKG_USE_PROXY="1"
 #QPKG_PROXY_PATH="/qpkg_name"
 
 #Desktop Application (since 4.1)
 # Set value to 1 means to open the QPKG's Web UI inside QTS desktop instead of new window.
-#QPKG_DESKTOP_APP="1"
+QPKG_DESKTOP_APP="1"
 # Desktop Application Window default inner width (since 4.1) (not over 1178)
 #QPKG_DESKTOP_APP_WIN_WIDTH=""
 # Desktop Application Window default inner height (since 4.1) (not over 600)

--- a/build/QNAP_NAS/megacmdpkg/qpkg.cfg
+++ b/build/QNAP_NAS/megacmdpkg/qpkg.cfg
@@ -31,9 +31,9 @@ QPKG_SERVICE_PROGRAM="MEGAcmd.sh"
 # Relative path to web interface
 QPKG_WEBUI="/MEGAcmd/"
 # Port number for the web interface.
-QPKG_WEB_PORT="80"
+#QPKG_WEB_PORT="80"
 # Port number for the SSL web interface.
-QPKG_WEB_SSL_PORT="8081"
+#QPKG_WEB_SSL_PORT="8081"
 
 # Use QTS HTTP Proxy and set Proxy_Path in the qpkg.conf. 
 # When the QPKG has its own HTTP service port, and want clients to connect via QTS HTTP port (default 8080).

--- a/build/QNAP_NAS/megacmdpkg/shared/MEGAcmd.sh
+++ b/build/QNAP_NAS/megacmdpkg/shared/MEGAcmd.sh
@@ -13,7 +13,6 @@ case "$1" in
     fi
     echo "MEGA-cmd is a console tool, and can be invoked via an ssh connection.  Executables are at %QPKG_ROOT"
     sed -i -e "s#%%%#$QPKG_ROOT#" $QPKG_ROOT/web/index.html
-    sed -i -e "s#QNAP NAS IP.*#QNAP NAS IP is `ifconfig eth0 | grep inet`#" $QPKG_ROOT/web/index.html
     ln -s $QPKG_ROOT/web /home/Qhttpd/Web/MEGAcmd
     ;;
 

--- a/build/QNAP_NAS/megacmdpkg/shared/MEGAcmd.sh
+++ b/build/QNAP_NAS/megacmdpkg/shared/MEGAcmd.sh
@@ -12,6 +12,9 @@ case "$1" in
         exit 1
     fi
     echo "MEGA-cmd is a console tool, and can be invoked via an ssh connection.  Executables are at %QPKG_ROOT"
+    sed -i -e "s#%%%#$QPKG_ROOT#" $QPKG_ROOT/web/index.html
+    sed -i -e "s#QNAP NAS IP.*#QNAP NAS IP is `ifconfig eth0 | grep inet`#" $QPKG_ROOT/web/index.html
+    ln -s $QPKG_ROOT/web /home/Qhttpd/Web/MEGAcmd
     ;;
 
   stop)

--- a/build/QNAP_NAS/megacmdpkg/shared/web/index.html
+++ b/build/QNAP_NAS/megacmdpkg/shared/web/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>Welcome to MEGAcmd</title>
+</head>
+<body>
+MEGAcmd is a command line tool.   Now that it is installed, please connect to your QNAP NAS drive with ssh, PuTTY, or similar.  The executables are at %%%.  In order
+for the scripts to work, please add that path to your PATH.
+</body>
+</html>
+

--- a/build/QNAP_NAS/megacmdpkg/shared/web/index.html
+++ b/build/QNAP_NAS/megacmdpkg/shared/web/index.html
@@ -6,8 +6,6 @@
 MEGAcmd is a command line tool.   Now that it is installed, please connect to your QNAP NAS drive with ssh, PuTTY, or similar.  The executables are at %%%.
 In order for the scripts to work, please add that path to your PATH.
 <p>
-Your QNAP NAS IP is:
-<p>
 Here is an example session:
 <p>
 <tt>

--- a/build/QNAP_NAS/megacmdpkg/shared/web/index.html
+++ b/build/QNAP_NAS/megacmdpkg/shared/web/index.html
@@ -3,8 +3,69 @@
 <title>Welcome to MEGAcmd</title>
 </head>
 <body>
-MEGAcmd is a command line tool.   Now that it is installed, please connect to your QNAP NAS drive with ssh, PuTTY, or similar.  The executables are at %%%.  In order
-for the scripts to work, please add that path to your PATH.
+MEGAcmd is a command line tool.   Now that it is installed, please connect to your QNAP NAS drive with ssh, PuTTY, or similar.  The executables are at %%%.
+In order for the scripts to work, please add that path to your PATH.
+<p>
+Your QNAP NAS IP is:
+<p>
+Here is an example session:
+<p>
+<tt>
+<PRE>
+login as: admin
+admin@10.12.0.248's password:
+[~] # export PATH=/share/CACHEDEV1_DATA/.qpkg/MEGAcmd:$PATH
+[~] # mega-cmd
+
+.=============================================================================.
+|                __  __ _____ ____    _                      _                |
+|               |  \/  | ___|/ ___|  / \   ___ _ __ ___   __| |               |
+|               | |\/| | \  / |  _  / _ \ / __| '_ ` _ \ / _` |               |
+|               | |  | | /__\ |_| |/ ___ \ (__| | | | | | (_| |               |
+|               |_|  |_|____|\____/_/   \_\___|_| |_| |_|\__,_|               |
+|                                                                             |
+|        Welcome to MEGAcmd! A Command Line Interactive and Scriptable        |
+|               Application to interact with your MEGA account                |
+|              This is a BETA version, it might not be bug-free.              |
+|     Also, the signature/output of the commands may change in a future.      |
+|          Please write to support@mega.nz if you find any issue or           |
+|             have any suggestion concerning its functionalities.             |
+|  Enter "help --non-interactive" to learn how to use MEGAcmd with scripts.   |
+|        Enter "help" for basic info and a list of available commands.        |
+`=============================================================================´
+[Initiating server in background. Log: /root/.megaCmd/megacmdserver.log]
+
+MEGA CMD&gt; help
+Here is the list of available commands and their usage
+Use "help -f" to get a brief description of the commands
+You can get further help on a specific command with "command" --help
+Alternatively, you can use "help" -ff to get a complete description of all commands
+Use "help --non-interactive" to learn how to use MEGAcmd with scripts
+Use "help --upgrade" to learn about the limitations and obtaining PRO accounts
+
+Commands:
+      attr                invite                    pwd
+      cd                  ipc                       quit
+      clear               killsession               reload
+      completion          lcd                       rm
+      confirm             log                       session
+      cp                  login                     share
+      debug               logout                    showpcr
+      deleteversions      lpwd                      signup
+      du                  ls                        speedlimit
+      exclude             masterkey                 sync
+      exit                mkdir                     thumbnail
+      export              mount                     transfers
+      find                mv                        userattr
+      get                 passwd                    users
+      help                permissions               version
+      https               preview                   whoami
+      import              put
+
+Verbosity: You can increase the amount of information given by any command by passing "-v" ("-vv", "-vvv", ...)
+MEGA CMD&gt;
+</PRE>
+</tt>
 </body>
 </html>
 

--- a/src/megacmdshell/megacmdshellcommunications.cpp
+++ b/src/megacmdshell/megacmdshellcommunications.cpp
@@ -456,8 +456,12 @@ SOCKET MegaCmdShellCommunications::createSocket(int number, bool initializeserve
                     const char executable2[] = "./MEGAcmdLoader";
     #else
                     const char executable[] = "mega-cmd-server";
+        #ifdef __linux__
                     char executable2[PATH_MAX];
                     sprintf(executable2, "%s/mega-cmd-server", getCurrentExecPath().c_str());
+        #else
+                    const char executable2[] = "./mega-cmd-server";
+        #endif
     #endif
 #endif
                     char * args[] = {NULL};


### PR DESCRIPTION
Includes changes for building for QNAP's x31 platform (x19 previously was very old, but that's the one available in their online documentation).   Also including a few changes based on feedback from QNAP for smooth package deployment.  This package configuration with a build of MEGAcmd 0.9.8 has gone through a couple of levels of checking by QNAP now, and should appear in their App Center soon.  This PR also includes a merged change which means that by default the mega-cmd-server can be automatically started even if the user has not adjusted their path.