### PR TITLE
fix for Synology package start script when install log name contains …

### DIFF
--- a/build/SynologyNAS/toolkit/source/megacmdpkg/SynoBuildConf/build
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/SynoBuildConf/build
@@ -15,7 +15,7 @@ export SPECIAL_OPENSSL_CONFIG_PARAMS=""
 export CC=$CC
 export CXX=$CXX
 export LD=$LD
-export CFLAGS="$CFLAGS -O3 -fexceptions -fvisibility=hidden -static"
+export CFLAGS="$CFLAGS -O2 -fexceptions -fvisibility=hidden -static"
 export CPPFLAGS="$CPPFLAGS -DNDEBUG"
 export CXXFLAGS="-std=c++11 $CFLAGS -DNDEBUG -DENABLE_BACKUPS -DMEGACMD_USERAGENT_SUFFIX=QNAP -DHAVE_LIBUV"
 export AR=$AR
@@ -149,7 +149,7 @@ pwd
 mkdir -p norecurse
 mv norecurse/* .
 
-./contrib/build_sdk.sh -a -e $suppress_freeimage_flag -g -I -n -q -R -v -X -C "$CUSTOM_CONFIG_ARGS" -O $OS_COMPILER_FOR_OPENSSL -S "$SPECIAL_OPENSSL_CONFIG_PARAMS" 2>&1 | tee /mybuildlogs-sdkbuild.out
+./contrib/build_sdk.sh -a -e $suppress_freeimage_flag -g -I -n -q -R -v -X -0 -C "$CUSTOM_CONFIG_ARGS" -O $OS_COMPILER_FOR_OPENSSL -S "$SPECIAL_OPENSSL_CONFIG_PARAMS" 2>&1 | tee /mybuildlogs-sdkbuild.out
 
 if ! [ -e src/libmega.la ] ; then
     echo "libtool could not link it so we do it ourselves. Including Zen and MediaInfo somehow reference a nonexistent path /home/chingfen in the Synology libtool libraries. If we left those out it would make the lib ok."

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/start-stop-status
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/start-stop-status
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "Please use telnet/ssh/PuTTY or similar to connect and use MEGAcmd.  Executables are at $SYNOPKG_PKGDEST/" > $SYNOPKG_TEMP_LOGFILE
+echo "Please use telnet/ssh/PuTTY or similar to connect and use MEGAcmd.  Executables are at $SYNOPKG_PKGDEST/" > "$SYNOPKG_TEMP_LOGFILE"
 exit 3 


### PR DESCRIPTION
…spaces (error reported by Synology)

(also some build settings I had not pushed back to the repo earlier)