### PR TITLE
Synology suggested changes: symbolic links from /usr/local/bin,

### DIFF
--- a/build/SynologyNAS/toolkit/source/megacmdpkg/INFO.sh
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/INFO.sh
@@ -3,17 +3,18 @@
 source /pkgscripts/include/pkg_util.sh
 
 package="MEGAcmd"   
-version="0.9.9000"
+version="0.9.9"
 displayname="MEGAcmd"        
 maintainer="Mega NZ"      
 arch="$(pkg_get_unified_platform)"
-description="MEGAcmd command line tool"
+description="MEGAcmd command line tool.  Access your MEGA.nz secure cloud storage account and upload/download files, use its commands in scripts, automatically synchronise folders between your MEGA.nz account and your Synology NAS.  Connect to your NAS via ssh or Putty to use the MEGAcmd commands.  Run mega-help from the command line for documentation, or see our User Guide online."
 os_min_ver="6.1-14715"
 maintainer="Mega Ltd."
 maintaner_url="https://MEGA.nz"
 support_url="https://mega.nz/help"
 helpurl="https://github.com/meganz/MEGAcmd/blob/master/UserGuide.md"
 thirdparty="yes"
+ctl_stop="no"
 [ "$(caller)" != "0 NULL" ] && return 0
 pkg_dump_info
 

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postinst
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postinst
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-for C in mega-attr mega-backup mega-cd mega-cmd mega-cmd-server mega-confirm mega-cp mega-debug mega-deleteversions mega-du mega-exclude mega-exec mega-export mega-find mega-get mega-help mega-https mega-import mega-invite mega-ipc mega-killsession mega-lcd mega-log mega-login mega-logout mega-lpwd mega-ls mega-mkdir mega-mount mega-mv mega-passwd mega-permissions mega-preview mega-put mega-pwd mega-quit mega-reload mega-rm mega-session mega-share mega-showpcr mega-signup mega-speedlimit mega-sync mega-thumbnail mega-transfers mega-userattr mega-users mega-versio mega-webdav mega-whoami
+for C in "$SYNOPKG_PKGDEST/mega-"*
 do
-  ln -s $SYNOPKG_PKGDEST/$C /usr/local/bin/$C
+  ln -s "$C" "/usr/local/bin/${C/$SYNOPKG_PKGDEST/}"
 done
 
 exit 0

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postinst
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postinst
@@ -1,3 +1,9 @@
 #!/bin/bash
+
+for C in mega-attr mega-backup mega-cd mega-cmd mega-cmd-server mega-confirm mega-cp mega-debug mega-deleteversions mega-du mega-exclude mega-exec mega-export mega-find mega-get mega-help mega-https mega-import mega-invite mega-ipc mega-killsession mega-lcd mega-log mega-login mega-logout mega-lpwd mega-ls mega-mkdir mega-mount mega-mv mega-passwd mega-permissions mega-preview mega-put mega-pwd mega-quit mega-reload mega-rm mega-session mega-share mega-showpcr mega-signup mega-speedlimit mega-sync mega-thumbnail mega-transfers mega-userattr mega-users mega-versio mega-webdav mega-whoami
+do
+  ln -s $SYNOPKG_PKGDEST/$C /usr/local/bin/$C
+done
+
 exit 0
 

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postuninst
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postuninst
@@ -1,9 +1,4 @@
 #!/bin/bash
 
-for C in mega-attr mega-backup mega-cd mega-cmd mega-cmd-server mega-confirm mega-cp mega-debug mega-deleteversions mega-du mega-exclude mega-exec mega-export mega-find mega-get mega-help mega-https mega-import mega-invite mega-ipc mega-killsession mega-lcd mega-log mega-login mega-logout mega-lpwd mega-ls mega-mkdir mega-mount mega-mv mega-passwd mega-permissions mega-preview mega-put mega-pwd mega-quit mega-reload mega-rm mega-session mega-share mega-showpcr mega-signup mega-speedlimit mega-sync mega-thumbnail mega-transfers mega-userattr mega-users mega-versio mega-webdav mega-whoami
-do
-  rm /usr/local/bin/$C
-done
-
 exit 0
 

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postuninst
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/postuninst
@@ -1,3 +1,9 @@
 #!/bin/bash
+
+for C in mega-attr mega-backup mega-cd mega-cmd mega-cmd-server mega-confirm mega-cp mega-debug mega-deleteversions mega-du mega-exclude mega-exec mega-export mega-find mega-get mega-help mega-https mega-import mega-invite mega-ipc mega-killsession mega-lcd mega-log mega-login mega-logout mega-lpwd mega-ls mega-mkdir mega-mount mega-mv mega-passwd mega-permissions mega-preview mega-put mega-pwd mega-quit mega-reload mega-rm mega-session mega-share mega-showpcr mega-signup mega-speedlimit mega-sync mega-thumbnail mega-transfers mega-userattr mega-users mega-versio mega-webdav mega-whoami
+do
+  rm /usr/local/bin/$C
+done
+
 exit 0
 

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/preuninst
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/preuninst
@@ -1,3 +1,8 @@
 #!/bin/bash
-exit 0
 
+for C in "$SYNOPKG_PKGDEST/mega-"*
+do
+  rm "/usr/local/bin/${C/$SYNOPKG_PKGDEST/}"
+done
+
+exit 0

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/start-stop-status
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/start-stop-status
@@ -2,13 +2,22 @@
 #if changed check no errors are logged in /var/log/bash_err.log on install or run steps
 
 if [ "$SYNOPKG_TEMP_LOGFILE" = "" ] ; then
-   exit 3
+    exit 0
 fi
 
-echo "" > "$SYNOPKG_TEMP_LOGFILE" 2> /dev/null
+case $1 in
+    start)
+        exit 0
+        ;;
+    stop)
+        exit 0
+        ;;
+    status)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
 
-if [ -e "$SYNOPKG_TEMP_LOGFILE" ] && [ -w "$SYNOPKG_TEMP_LOGFILE" ] ; then
-   echo "Please use telnet/ssh/PuTTY or similar to connect and use MEGAcmd.  Executables are at $SYNOPKG_PKGDEST/ " >> "$SYNOPKG_TEMP_LOGFILE"
-fi
 
-exit 3 

--- a/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/start-stop-status
+++ b/build/SynologyNAS/toolkit/source/megacmdpkg/scripts/start-stop-status
@@ -1,23 +1,4 @@
 #!/bin/sh
 #if changed check no errors are logged in /var/log/bash_err.log on install or run steps
 
-if [ "$SYNOPKG_TEMP_LOGFILE" = "" ] ; then
-    exit 0
-fi
-
-case $1 in
-    start)
-        exit 0
-        ;;
-    stop)
-        exit 0
-        ;;
-    status)
-        exit 0
-        ;;
-    *)
-        exit 0
-        ;;
-esac
-
-
+exit 0

--- a/src/comunicationsmanagerfilesockets.cpp
+++ b/src/comunicationsmanagerfilesockets.cpp
@@ -29,6 +29,7 @@
 #endif
 
 using namespace mega;
+using namespace std;
 
 int ComunicationsManagerFileSockets::get_next_comm_id()
 {

--- a/src/comunicationsmanagerportsockets.cpp
+++ b/src/comunicationsmanagerportsockets.cpp
@@ -39,6 +39,7 @@
 #endif
 
 using namespace mega;
+using namespace std;
 
 void closeSocket(SOCKET socket){
 #ifdef _WIN32

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -140,6 +140,7 @@ std::ostringstream & operator<< ( std::ostringstream & ostr, std::wstring const 
 #endif
 
 using namespace mega;
+using namespace std;
 
 MegaCmdExecuter *cmdexecuter;
 MegaCmdSandbox *sandboxCMD;

--- a/src/megacmdexecuter.cpp
+++ b/src/megacmdexecuter.cpp
@@ -35,6 +35,7 @@
 #include <signal.h>
 
 using namespace mega;
+using namespace std;
 
 static const char* rootnodenames[] = { "ROOT", "INBOX", "RUBBISH" };
 static const char* rootnodepaths[] = { "/", "//in", "//bin" };


### PR DESCRIPTION
and no option to 'stop' the package.
Also added `using namespace std;` where needed for building against SDK
3.4.1.