### PR TITLE
Updated MEGAcmd for Win32 so it doesn't use the `readline` library.

### DIFF
--- a/src/configurationmanager.cpp
+++ b/src/configurationmanager.cpp
@@ -35,6 +35,10 @@
 #define PATH_MAX_LOCAL_BACKUP PATH_MAX
 #endif
 
+#if defined(_WIN32)
+#define unlink _unlink  
+#endif
+
 using namespace std;
 using namespace mega;
 

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -213,8 +213,10 @@ string avalidCommands [] = { "login", "signup", "confirm", "session", "mount", "
                              , "backup"
 #endif
                              , "deleteversions"
-#ifdef _WIN32
-                             ,"unicode"
+#if defined(_WIN32) && defined(NO_READLINE)
+                             , "autocomplete", "codepage"
+#elif defined(_WIN32)
+                             , "unicode"
 #else
                              , "permissions"
 #endif
@@ -1383,10 +1385,12 @@ const char * getUsageStr(const char *command)
     {
         return "mount";
     }
+#if defined(_WIN32) && !defined(NO_READLINE)
     if (!strcmp(command, "unicode"))
     {
         return "unicode";
     }
+#endif
     if (!strcmp(command, "ls"))
     {
 #ifdef USE_PCRE
@@ -1699,6 +1703,16 @@ const char * getUsageStr(const char *command)
     {
         return "transfers [-c TAG|-a] | [-r TAG|-a]  | [-p TAG|-a] [--only-downloads | --only-uploads] [SHOWOPTIONS]";
     }
+#if defined(_WIN32) && defined(NO_READLINE)
+    if (!strcmp(command, "autocomplete"))
+    {
+        return "autocomplete [dos | unix]";
+    }
+    else if (!strcmp(command, "codepage"))
+    {
+        return "codepage [N [M]]";
+    }
+#endif
     return "command not found: ";
 }
 
@@ -1811,6 +1825,7 @@ string getHelpStr(const char *command)
     {
         os << "Lists all the main nodes" << endl;
     }
+#if defined(_WIN32) && !defined(NO_READLINE)
     else if (!strcmp(command, "unicode"))
     {
         os << "Toggle unicode input enabled/disabled in interactive shell" << endl;
@@ -1819,8 +1834,8 @@ string getHelpStr(const char *command)
         os << " some issues interacting with the console" << endl;
         os << " (e.g. history navigation fails)." << endl;
         os << "Type \"help --unicode\" for further info" << endl;
-
     }
+#endif
     else if (!strcmp(command, "ls"))
     {
         os << "Lists files in a remote path" << endl;
@@ -2498,6 +2513,30 @@ string getHelpStr(const char *command)
         os << " --limit=N" << "\t" << "Show only first N transfers" << endl;
         os << " --path-display-size=N" << "\t" << "Use a fixed size of N characters for paths" << endl;
     }
+#if defined(_WIN32) && defined(NO_READLINE)
+    else if (!strcmp(command, "autocomplete"))
+    {
+        os << "Modifes how tab completion operates." << endl;
+        os << endl;
+        os << "The default is to operate like the native platform. However" << endl;
+        os << "you can switch it between mode 'dos' and 'unix' as you prefer." << endl;
+        os << "Options:" << endl;
+        os << " dos" << "\t" << "Each press of tab places the next option into the command line" << endl;
+        os << " unix" << "\t" << "Options are listed in a table, or put in-line if there is only one" << endl;
+    }
+    else if (!strcmp(command, "codepage"))
+    {
+        os << "Switches the codepage used to decide which characters show on-screen." << endl;
+        os << endl;
+        os << "MEGAcmd supports unicode or specific code pages.  For european countries you may need" << endl;
+        os << "to select a suitable codepage or secondary codepage for the character set you use." << endl;
+        os << "Of course a font containing the glyphs you need must have been selected for the terminal first." << endl;
+        os << "Options:" << endl;
+        os << " (no option)" << "\t" << "Outputs the selected code page and secondary codepage (if configured)." << endl;
+        os << " N" << "\t" << "Sets the main codepage to N. 65001 is Unicode." << endl;
+        os << " M" << "\t" << "Sets the secondary codepage to M, which is used if the primary can't translate a character." << endl;
+    }
+#endif
     return os.str();
 }
 
@@ -2738,7 +2777,22 @@ void executecommand(char* ptr)
 
 #endif
         }
-#ifdef _WIN32
+
+#if defined(_WIN32) && defined(NO_READLINE)
+        else if (getFlag(&clflags, "unicode"))
+        {
+            OUTSTREAM << "Unicode support has been considerably improved in the interactive console in version 1.0.0." << endl;
+            OUTSTREAM << "If you do experience issues with it, please do not hesistate to contact us." << endl;
+            OUTSTREAM << endl;
+            OUTSTREAM << "Known issues: " << endl;
+            OUTSTREAM << endl;
+            OUTSTREAM << "If some symbols are not displaying, or displaying correctly, please first check you have a suitable font" << endl;
+            OUTSTREAM << "selected, and a suitable codepage. See \"help codepage\" for details on that." << endl;
+            OUTSTREAM << "When using the non-interactive mode (See \"help --non-interactive\"), piping or redirecting can be quite" << endl;
+            OUTSTREAM << "problematic due to different encoding expectations between programs.  You can use \"-o outputfile\" with your " << endl;
+            OUTSTREAM << "mega-*.bat commands to have the output written to a file in UTF-8, and then open it with a suitable editor." << endl;
+        }
+#elif defined(_WIN32)
         else if (getFlag(&clflags,"unicode"))
         {
             OUTSTREAM << "A great effort has been done so as to have MEGAcmd support non-ASCII characters." << endl;

--- a/src/megacmdexecuter.cpp
+++ b/src/megacmdexecuter.cpp
@@ -348,10 +348,10 @@ MegaNode* MegaCmdExecuter::nodebypath(const char* ptr, string* user, string* nam
                 bool isversion = nodeNameIsVersion(curName);
                 if (isversion)
                 {
-                    MegaNode *baseNode = api->getChildNode(baseNode, curName.substr(0,curName.size()-11).c_str());
-                    if (baseNode)
+                    MegaNode *childNode = api->getChildNode(baseNode, curName.substr(0,curName.size()-11).c_str());
+                    if (childNode)
                     {
-                        MegaNodeList *versionNodes = api->getVersions(baseNode);
+                        MegaNodeList *versionNodes = api->getVersions(childNode);
                         if (versionNodes)
                         {
                             for (int i = 0; i < versionNodes->size(); i++)
@@ -365,7 +365,7 @@ MegaNode* MegaCmdExecuter::nodebypath(const char* ptr, string* user, string* nam
                             }
                             delete versionNodes;
                         }
-                        delete baseNode;
+                        delete childNode;
                     }
                 }
                 else

--- a/src/megacmdlogger.cpp
+++ b/src/megacmdlogger.cpp
@@ -25,6 +25,7 @@ using namespace std;
 using namespace mega;
 
 // different outstreams for every thread. to gather all the output data
+MUTEX_CLASS threadLookups(false);
 map<uint64_t, OUTSTREAMTYPE *> outstreams;
 map<uint64_t, int> threadLogLevel;
 map<uint64_t, int> threadoutCode;
@@ -33,6 +34,7 @@ map<uint64_t, bool> threadIsCmdShell;
 
 OUTSTREAMTYPE &getCurrentOut()
 {
+    MutexGuard g(threadLookups);
     uint64_t currentThread = MegaThread::currentThreadId();
     if (outstreams.find(currentThread) == outstreams.end())
     {
@@ -52,6 +54,8 @@ bool interactiveThread()
     }
 
     unsigned long long currentThread = MegaThread::currentThreadId();
+
+    MutexGuard g(threadLookups);
     if (outstreams.find(currentThread) == outstreams.end())
     {
         return true;
@@ -65,6 +69,8 @@ bool interactiveThread()
 int getCurrentOutCode()
 {
     unsigned long long currentThread = MegaThread::currentThreadId();
+
+    MutexGuard g(threadLookups);
     if (threadoutCode.find(currentThread) == threadoutCode.end())
     {
         return 0; //default OK
@@ -79,6 +85,8 @@ int getCurrentOutCode()
 CmdPetition * getCurrentPetition()
 {
     unsigned long long currentThread = MegaThread::currentThreadId();
+
+    MutexGuard g(threadLookups);
     if (threadpetition.find(currentThread) == threadpetition.end())
     {
         return NULL;
@@ -92,6 +100,8 @@ CmdPetition * getCurrentPetition()
 int getCurrentThreadLogLevel()
 {
     unsigned long long currentThread = MegaThread::currentThreadId();
+
+    MutexGuard g(threadLookups);
     if (threadLogLevel.find(currentThread) == threadLogLevel.end())
     {
         return -1;
@@ -105,6 +115,8 @@ int getCurrentThreadLogLevel()
 bool getCurrentThreadIsCmdShell()
 {
     unsigned long long currentThread = MegaThread::currentThreadId();
+
+    MutexGuard g(threadLookups);
     if (threadIsCmdShell.find(currentThread) == threadIsCmdShell.end())
     {
         return false; //default not
@@ -118,26 +130,31 @@ bool getCurrentThreadIsCmdShell()
 
 void setCurrentThreadLogLevel(int level)
 {
+    MutexGuard g(threadLookups);
     threadLogLevel[MegaThread::currentThreadId()] = level;
 }
 
 void setCurrentThreadOutStream(OUTSTREAMTYPE *s)
 {
+    MutexGuard g(threadLookups);
     outstreams[MegaThread::currentThreadId()] = s;
 }
 
 void setCurrentThreadIsCmdShell(bool isit)
 {
+    MutexGuard g(threadLookups);
     threadIsCmdShell[MegaThread::currentThreadId()] = isit;
 }
 
 void setCurrentOutCode(int outCode)
 {
+    MutexGuard g(threadLookups);
     threadoutCode[MegaThread::currentThreadId()] = outCode;
 }
 
 void setCurrentPetition(CmdPetition *petition)
 {
+    MutexGuard g(threadLookups);
     threadpetition[MegaThread::currentThreadId()] = petition;
 }
 

--- a/src/megacmdshell/megacmdshell.cpp
+++ b/src/megacmdshell/megacmdshell.cpp
@@ -21,8 +21,12 @@
 #define USE_VARARGS
 #define PREFER_STDARG
 
+#ifdef NO_READLINE
+#include <megaconsole.h>
+#else
 #include <readline/readline.h>
 #include <readline/history.h>
+#endif
 
 #include <iomanip>
 #include <string>
@@ -54,29 +58,19 @@
 #endif
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
-  #define snprintf _snprintf
-  #define vsnprintf _vsnprintf
-  #define strcasecmp _stricmp
-  #define strncasecmp _strnicmp
+#if defined(_WIN32)
+  #define strdup _strdup
 #endif
 
 #define SSTR( x ) static_cast< const std::ostringstream & >( \
         (  std::ostringstream() << std::dec << x ) ).str()
 
-#if defined(_WIN32) && !defined(WINDOWS_PHONE)
-#include "mega/thread/win32thread.h"
-class MegaMutex : public mega::Win32Mutex {};
-#elif defined(USE_CPPTHREAD)
-#include "mega/thread/cppthread.h"
-class MegaMutex : public mega::CppMutex {};
-#else
-#include "mega/thread/posixthread.h"
-class MegaMutex : public mega::PosixMutex {};
-#endif
-
-
 using namespace std;
+using namespace mega;
+
+#if defined(NO_READLINE) && defined(_WIN32)
+CONSOLE_CLASS* console = NULL;
+#endif
 
 
 // utility functions
@@ -103,6 +97,7 @@ void replaceAll(std::string& str, const std::string& from, const std::string& to
     }
 }
 
+#ifndef NO_READLINE
 string getCurrentLine()
 {
     char *saved_line = rl_copy_text(0, rl_point);
@@ -111,6 +106,7 @@ string getCurrentLine()
     saved_line = NULL;
     return toret;
 }
+#endif
 
 void sleepSeconds(int seconds)
 {
@@ -121,12 +117,12 @@ void sleepSeconds(int seconds)
 #endif
 }
 
-void sleepMicroSeconds(long microseconds)
+void sleepMilliSeconds(long milliseconds)
 {
 #ifdef _WIN32
-    Sleep(microseconds);
+    Sleep(milliseconds);
 #else
-    usleep(microseconds*1000);
+    usleep(milliseconds *1000);
 #endif
 }
 
@@ -294,7 +290,7 @@ bool confirmingcancellink = false;
 // communications with megacmdserver:
 MegaCmdShellCommunications *comms;
 
-MegaMutex mutexPrompt;
+MUTEX_CLASS mutexPrompt(false);
 
 void printWelcomeMsg(unsigned int width = 0);
 
@@ -387,6 +383,7 @@ void sigint_handler(int signum)
         setprompt(COMMAND);
     }
 
+#ifndef NO_READLINE
     // reset position and print prompt
     rl_replace_line("", 0); //clean contents of actual command
     rl_crlf(); //move to nextline
@@ -404,6 +401,7 @@ void sigint_handler(int signum)
         rl_reset_line_state();
     }
     rl_redisplay();
+#endif
 }
 
 
@@ -432,7 +430,7 @@ void printprogress(long long completed, long long total, const char *title)
     }
     else
     {
-        percentDowloaded = completed * 1.0 / total * 100.0;
+        percentDowloaded = float(completed * 1.0 / total * 100.0);
     }
     if (completed != PROGRESS_COMPLETE && (alreadyFinished || ( ( percentDowloaded == oldpercent ) && ( oldpercent != 0 ) ) ))
     {
@@ -478,7 +476,7 @@ void printprogress(long long completed, long long total, const char *title)
 
 
 #ifdef _WIN32
-BOOL CtrlHandler( DWORD fdwCtrlType )
+BOOL WINAPI CtrlHandler( DWORD fdwCtrlType )
 {
   cerr << "Reached CtrlHandler: " << fdwCtrlType << endl;
 
@@ -504,6 +502,7 @@ void setprompt(prompttype p, string arg)
 {
     prompt = p;
 
+#ifndef NO_READLINE
     if (p == COMMAND)
     {
         console_setecho(true);
@@ -521,8 +520,18 @@ void setprompt(prompttype p, string arg)
         }
         console_setecho(false);
     }
+#else
+    console->setecho(p == COMMAND);
+    
+    if (p != COMMAND)
+    {
+        pw_buf_pos = 0;
+        console->updateInputPrompt(arg.empty() ? prompts[p] : arg);
+    }
+#endif
 }
 
+#ifndef NO_READLINE
 // readline callback - exit if EOF, add to history unless password
 static void store_line(char* l)
 {
@@ -550,13 +559,14 @@ static void store_line(char* l)
 
     line = l;
 }
+#endif
 
 #ifdef _WIN32
 
 bool validoptionforreadline(const string& string)
 {// TODO: this has not been tested in 100% cases (perhaps it is too diligent or too strict)
     int c,i,ix,n,j;
-    for (i=0, ix=string.length(); i < ix; i++)
+    for (i=0, ix=int(string.length()); i < ix; i++)
     {
         c = (unsigned char) string[i];
 
@@ -613,6 +623,7 @@ wstring escapereadlinebreakers(const wchar_t *what)
 }
 #endif
 
+#ifndef NO_READLINE
 void install_rl_handler(const char *theprompt)
 {
 #ifdef _WIN32
@@ -654,15 +665,19 @@ void install_rl_handler(const char *theprompt)
     rl_callback_handler_install(theprompt, store_line);
 #endif
 }
+#endif
 
 void changeprompt(const char *newprompt, bool redisplay)
 {
+    MutexGuard g(mutexPrompt);
+#ifdef NO_READLINE
+    console->updateInputPrompt(newprompt);
+#else
     if (*dynamicprompt)
     {
         if (!strcmp(newprompt,dynamicprompt))
             return; //same prompt. do nth
     }
-    mutexPrompt.lock();
 
     strncpy(dynamicprompt, newprompt, sizeof( dynamicprompt ));
 
@@ -705,23 +720,24 @@ void changeprompt(const char *newprompt, bool redisplay)
         handlerinstalled = true;
 
         requirepromptinstall = false;
-
-        static bool firstime = true;
-        if (firstime)
-        {
-            firstime = false;
-#if _WIN32
-            if( !SetConsoleCtrlHandler( (PHANDLER_ROUTINE) CtrlHandler, TRUE ) )
-            {
-                cerr << "Control handler set failed" << endl;
-            }
-#else
-            // prevent CTRL+C exit
-            signal(SIGINT, sigint_handler);
-#endif
-        }
     }
-    mutexPrompt.unlock();
+
+#endif
+
+    static bool firstime = true;
+    if (firstime)
+    {
+        firstime = false;
+#if _WIN32
+        if( !SetConsoleCtrlHandler( CtrlHandler, TRUE ) )
+        {
+            cerr << "Control handler set failed" << endl;
+        }
+#else
+        // prevent CTRL+C exit
+        signal(SIGINT, sigint_handler);
+#endif
+    }
 }
 
 void escapeEspace(string &orig)
@@ -734,6 +750,7 @@ void unescapeEspace(string &orig)
     replaceAll(orig,"\\ ", " ");
 }
 
+#ifndef NO_READLINE
 char* empty_completion(const char* text, int state)
 {
     // we offer 2 different options so that it doesn't complete (no space is inserted)
@@ -790,6 +807,8 @@ char* generic_completion(const char* text, int state, vector<string> validOption
 
     return((char*)NULL );
 }
+#endif
+
 
 inline bool ends_with(std::string const & value, std::string const & ending)
 {
@@ -824,7 +843,7 @@ void pushvalidoption(vector<string>  *validOptions, const char *beginopt)
 #endif
 }
 
-
+#ifndef NO_READLINE
 char* remote_completion(const char* text, int state)
 {
     char *saved_line = strdup(getCurrentLine().c_str());
@@ -1030,6 +1049,173 @@ void wait_for_input(int readline_fd)
         }
     }
 }
+#else
+
+void changedir(const string& where)
+{
+    string olddir;
+#ifdef _WIN32
+    wstring wwhere;
+    stringtolocalw(where.c_str(), &wwhere);
+    int r = SetCurrentDirectoryW((LPCWSTR)wwhere.data());
+    if (!r)
+    {
+        cerr << "Error at SetCurrentDirectoryW before local completion to " << where << ". errno: " << ERRNO << endl;
+    }
+#else
+    chdir(where.c_str());
+#endif
+}
+
+vector<autocomplete::ACState::Completion> remote_completion(const string& linetocomplete)
+{
+    vector<autocomplete::ACState::Completion> result;
+
+    // normalize any partially or intermediately quoted strings, eg.  `put c:\Program" Fi`
+    autocomplete::ACState acs = autocomplete::prepACState(linetocomplete, linetocomplete.size(), console->getAutocompleteStyle());
+    string refactoredline;
+    for (auto& s : acs.words)
+    {
+        refactoredline += (refactoredline.empty() ? "" : " ") + s.getQuoted();
+    }
+
+    OUTSTRING s;
+    OUTSTRINGSTREAM oss(s);
+    comms->executeCommand(string("completionshell ") + refactoredline, readresponse, oss);
+
+    string outputcommand;
+    localwtostring(&oss.str(), &outputcommand);
+
+    if (outputcommand == "MEGACMD_USE_LOCAL_COMPLETION")
+    {
+        return result;
+    }
+    else
+    {
+        autocomplete::ACState::quoted_word completionword = acs.words.size() ? acs.words[acs.words.size() - 1] : string();
+        if (strncmp(outputcommand.c_str(), "MEGACMD_USE_LOCAL_COMPLETION", 28) == 0)
+        {
+            changedir(outputcommand.substr(28));
+            autocomplete::CompletionState cs = autoComplete(completionword.getQuoted(), completionword.s.size(), autocomplete::localFSPath(), console->getAutocompleteStyle());
+            result.swap(cs.completions);
+        }
+        else
+        {
+            char *ptr = (char *)outputcommand.c_str();
+            char *beginopt = ptr;
+            while (*ptr)
+            {
+                if (*ptr == 0x1F)
+                {
+                    *ptr = '\0';
+                    if (strcmp(beginopt, " ")) //the server will give a " " for empty_completion (no matches)
+                    {
+                        result.push_back(autocomplete::ACState::Completion(beginopt, false));
+                    }
+
+                    beginopt = ptr + 1;
+                }
+                ptr++;
+            }
+            if (*beginopt && strcmp(beginopt, " "))
+            {
+                result.push_back(autocomplete::ACState::Completion(beginopt, false));
+            }
+
+            if (result.size() == 1 && result[0].s == completionword.s)
+            {
+                result.clear();  // for arguments it returns the same string when there are no matches
+            }
+        }
+        return result;
+    }
+}
+
+void exec_clear(autocomplete::ACState& s)
+{
+    console->clearScreen();
+}
+
+void exec_history(autocomplete::ACState& s)
+{
+    console->outputHistory();
+}
+
+void exec_dos_unix(autocomplete::ACState& s)
+{
+    if (s.words.size() < 2)
+    {
+        OUTSTREAM << "autocomplete style: " << (console->getAutocompleteStyle() ? "unix" : "dos") << endl;
+    }
+    else
+    {
+        console->setAutocompleteStyle(s.words[1].s == "unix");
+    }
+}
+
+void exec_codepage(autocomplete::ACState& s)
+{
+    if (s.words.size() == 1)
+    {
+        UINT cp1, cp2;
+        console->getShellCodepages(cp1, cp2);
+        cout << "Current codepage is " << cp1;
+        if (cp2 != cp1)
+        {
+            cout << " with failover to codepage " << cp2 << " for any absent glyphs";
+        }
+        cout << endl;
+        for (int i = 32; i < 256; ++i)
+        {
+            string theCharUtf8 = WinConsole::toUtf8String(WinConsole::toUtf16String(string(1, (char)i), cp1));
+            cout << "  dec/" << i << " hex/" << hex << i << dec << ": '" << theCharUtf8 << "'";
+            if (i % 4 == 3)
+            {
+                cout << endl;
+            }
+        }
+    }
+    else if (s.words.size() == 2 && atoi(s.words[1].s.c_str()) != 0)
+    {
+        if (!console->setShellConsole(atoi(s.words[1].s.c_str()), atoi(s.words[1].s.c_str())))
+        {
+            cout << "Code page change failed - unicode selected" << endl;
+        }
+    }
+    else if (s.words.size() == 3 && atoi(s.words[1].s.c_str()) != 0 && atoi(s.words[2].s.c_str()) != 0)
+    {
+        if (!console->setShellConsole(atoi(s.words[1].s.c_str()), atoi(s.words[2].s.c_str())))
+        {
+            cout << "Code page change failed - unicode selected" << endl;
+        }
+    }
+    else
+    {
+        cout << "      codepage [N [N]]" << endl;
+    }
+}
+
+
+autocomplete::ACN autocompleteSyntax;
+
+autocomplete::ACN buildAutocompleteSyntax()
+{
+    using namespace autocomplete;
+    std::unique_ptr<Either> p(new Either("      "));
+
+    p->Add(exec_clear,      sequence(text("clear")));
+    p->Add(exec_codepage,   sequence(text("codepage"), opt(sequence(wholenumber(65001), opt(wholenumber(65001))))));
+    p->Add(exec_dos_unix,   sequence(text("autocomplete"), opt(either(text("unix"), text("dos")))));
+    p->Add(exec_history,    sequence(text("history")));
+
+    return autocompleteSyntax = std::move(p);
+}
+
+void printHistory()
+{
+    console->outputHistory();
+}
+#endif
 
 bool isserverloggedin()
 {
@@ -1256,6 +1442,17 @@ void process_line(char * line)
         }
         case COMMAND:
         {
+
+#ifdef NO_READLINE
+            // local command and syntax is satisfied, execute it
+            string consoleOutput;
+            if (autocomplete::autoExec(line, string::npos, autocompleteSyntax, false, consoleOutput, false))
+            {
+                COUT << consoleOutput << flush;
+                return;
+            }
+#endif
+
             vector<string> words = getlistOfWords(line);
             bool helprequested = false;
             for (unsigned int i = 1; i< words.size(); i++)
@@ -1290,7 +1487,7 @@ void process_line(char * line)
                         printHistory();
                     }
                 }
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NO_READLINE)
                 else if (!helprequested && words[0] == "unicode" && words.size() == 1)
                 {
                     rl_getc_function=(rl_getc_function==&getcharacterreadlineUTF16support)?rl_getc:&getcharacterreadlineUTF16support;
@@ -1405,7 +1602,7 @@ void process_line(char * line)
                     }
                     return;
                 }
-                else if ( words[0] == "clear" )
+                else if (!helprequested && words[0] == "clear")
                 {
 #ifdef _WIN32
                     HANDLE hStdOut;
@@ -1574,6 +1771,7 @@ void process_line(char * line)
 }
 
 // main loop
+#ifndef NO_READLINE
 void readloop()
 {
     time_t lasttimeretrycons = 0;
@@ -1590,7 +1788,7 @@ void readloop()
     comms->registerForStateChanges(statechangehandle);
 
     //give it a while to communicate the state
-    sleepMicroSeconds(700);
+    sleepMilliSeconds(700);
 
 #if defined(_WIN32) && defined(USE_PORT_COMMS)
     // due to a failure in reconnecting to the socket, if the server was initiated in while registeringForStateChanges
@@ -1600,7 +1798,7 @@ void readloop()
         comms->registerForStateChanges(statechangehandle);
     }
     //give it a while to communicate the state
-    sleepMicroSeconds(1);
+    sleepMilliSeconds(1);
 #endif
 
     for (;; )
@@ -1714,6 +1912,91 @@ void readloop()
         }
     }
 }
+#else  // NO_READLINE
+void readloop()
+{
+    time_t lasttimeretrycons = 0;
+
+    comms->registerForStateChanges(statechangehandle);
+
+    //give it a while to communicate the state
+    sleepMilliSeconds(700);
+
+#if defined(_WIN32) && defined(USE_PORT_COMMS)
+    // due to a failure in reconnecting to the socket, if the server was initiated in while registeringForStateChanges
+    // in windows we would not be yet connected. we need to manually try to register again.
+    if (comms->registerAgainRequired)
+    {
+        comms->registerForStateChanges(statechangehandle);
+    }
+    //give it a while to communicate the state
+    sleepMilliSeconds(1);
+#endif
+
+    for (;; )
+    {
+        if (prompt == COMMAND)
+        {
+            console->updateInputPrompt(*dynamicprompt ? dynamicprompt : prompts[COMMAND]);
+        }
+
+        // command editing loop - exits when a line is submitted
+        for (;; )
+        {
+            line = console->checkForCompletedInputLine();
+
+            if (line)
+            {
+                break;
+            }
+            else
+            {
+                time_t tnow = time(NULL);
+                if ((tnow - lasttimeretrycons) > 5 && !doExit)
+                {
+                    comms->executeCommand("retrycons");
+                    lasttimeretrycons = tnow;
+                }
+
+                if (doExit)
+                {
+                    return;
+                }
+            }
+        }
+
+        if (line)
+        {
+            if (strlen(line))
+            {
+                alreadyFinished = false;
+                percentDowloaded = 0.0;
+                mutexPrompt.lock();
+                process_line(line);
+                requirepromptinstall = true;
+                mutexPrompt.unlock();
+
+                if (comms->registerAgainRequired)
+                {
+                    // register again for state changes
+                    comms->registerForStateChanges(statechangehandle);
+                    comms->registerAgainRequired = false;
+                }
+
+                // sleep, so that in case there was a changeprompt waiting, gets executed before relooping
+                // this is not 100% guaranteed to happen
+                sleepSeconds(0);
+            }
+            free(line);
+            line = NULL;
+        }
+        if (doExit)
+        {
+            return;
+        }
+    }
+}
+#endif
 
 class NullBuffer : public std::streambuf
 {
@@ -1728,7 +2011,7 @@ void printCenteredLine(string msj, unsigned int width, bool encapsulated = true)
 {
     if (msj.size()>width)
     {
-        width = msj.size();
+        width = unsigned(msj.size());
     }
     if (encapsulated)
         COUT << "|";
@@ -1773,7 +2056,9 @@ void printWelcomeMsg(unsigned int width)
     printCenteredLine("Enter \"help --non-interactive\" to learn how to use MEGAcmd with scripts.",width);
     printCenteredLine("Enter \"help\" for basic info and a list of available commands.",width);
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(NO_READLINE)
+    printCenteredLine("Unicode support in the console is improved, see \"help --unicode\"", width);
+#elif defined(_WIN32)
     printCenteredLine("Enter \"help --unicode\" for info regarding non-ASCII support.",width);
 #endif
 
@@ -1855,6 +2140,7 @@ void mycompletefunct(char **c, int num_matches, int max_length)
 }
 #endif
 
+#ifndef NO_READLINE
 std::string readresponse(const char* question)
 {
     string response;
@@ -1863,17 +2149,37 @@ std::string readresponse(const char* question)
     rl_replace_line("", 0);
     return response;
 }
+#else
+std::string readresponse(const char* question)
+{
+    COUT << question << flush;
+    console->updateInputPrompt(question);
+    for (;;)
+    {
+        if (char* line = console->checkForCompletedInputLine())
+        {
+            console->updateInputPrompt("");
+            string response(line);
+            free(line);
+            return response;
+        }
+        else
+        {
+            sleepMilliSeconds(200);
+        }
+    }
+}
+#endif
 
 
 int main(int argc, char* argv[])
 {
-#ifdef _WIN32
+
+#if defined(_WIN32) && !defined(NO_READLINE)
     // Set Environment's default locale
     setlocale(LC_ALL, "en-US");
     rl_completion_display_matches_hook = mycompletefunct;
 #endif
-
-    mutexPrompt.init(false);
 
     // intialize the comms object
 #if defined(_WIN32) && !defined(USE_PORT_COMMS)
@@ -1882,6 +2188,7 @@ int main(int argc, char* argv[])
     comms = new MegaCmdShellCommunications();
 #endif
 
+#ifndef NO_READLINE
     rl_attempted_completion_function = getCompletionMatches;
     rl_completer_quote_characters = "\"'";
     rl_filename_quote_characters  = " ";
@@ -1895,6 +2202,14 @@ int main(int argc, char* argv[])
         // so that we can use rl_message or rl_resize_terminal safely before ever
         // prompting anything.
     }
+#endif
+
+#if defined(_WIN32) && defined(NO_READLINE)
+    console = new CONSOLE_CLASS;
+    console->setAutocompleteSyntax(buildAutocompleteSyntax());
+    console->setAutocompleteFunction(remote_completion);
+    console->setShellConsole(CP_UTF8, GetConsoleOutputCP());
+#endif
 
 #ifdef _WIN32
     // in windows, rl_resize_terminal fails to resize before first prompt appears, we take the width from elsewhere
@@ -1904,15 +2219,16 @@ int main(int argc, char* argv[])
     columns = csbi.srWindow.Right - csbi.srWindow.Left - 2;
     printWelcomeMsg(columns);
 #else
-    sleepMicroSeconds(200); // this gives a little while so that the console is ready and rl_resize_terminal works fine
+    sleepMilliSeconds(200); // this gives a little while so that the console is ready and rl_resize_terminal works fine
     printWelcomeMsg();
 #endif
 
     readloop();
 
-
+#ifndef NO_READLINE
     clear_history();
     rl_callback_handler_remove(); //To avoid having the terminal messed up (requiring a "reset")
+#endif
     delete comms;
 
 }

--- a/src/megacmdshell/megacmdshellcommunications.cpp
+++ b/src/megacmdshell/megacmdshellcommunications.cpp
@@ -69,18 +69,6 @@
         ( std::ostringstream() << std::dec << x ) ).str()
 #endif
 
-#if defined(_WIN32) && !defined(WINDOWS_PHONE)
-#include "mega/thread/win32thread.h"
-class MegaThread : public mega::Win32Thread {};
-#elif defined(USE_CPPTHREAD)
-#include "mega/thread/cppthread.h"
-class MegaThread : public mega::CppThread {};
-#else
-#include "mega/thread/posixthread.h"
-class MegaThread : public mega::PosixThread {};
-#endif
-
-
 using namespace std;
 
 bool MegaCmdShellCommunications::serverinitiatedfromshell;

--- a/src/megacmdshell/megacmdshellcommunications.h
+++ b/src/megacmdshell/megacmdshellcommunications.h
@@ -22,8 +22,6 @@
 #ifndef MEGACMDSHELLCOMMUNICATIONS_H
 #define MEGACMDSHELLCOMMUNICATIONS_H
 
-#include "mega/thread.h"
-
 #include <string>
 #include <iostream>
 
@@ -36,6 +34,21 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/un.h>
+#endif
+
+
+#if defined(_WIN32) && !defined(WINDOWS_PHONE) && !defined(USE_CPPTHREAD)
+#include "mega/thread/win32thread.h"
+class MegaMutex : public ::mega::Win32Mutex {};
+class MegaThread : public ::mega::Win32Thread {};
+#elif defined(USE_CPPTHREAD)
+#include "mega/thread/cppthread.h"
+class MegaMutex : public ::mega::CppMutex {};
+class MegaThread : public ::mega::CppThread {};
+#else
+#include "mega/thread/posixthread.h"
+class MegaMutex : public ::mega::PosixMutex {};
+class MegaThread : public ::mega::PosixThread {};
 #endif
 
 

--- a/src/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
+++ b/src/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
@@ -42,17 +42,6 @@
 #define _O_U8TEXT 0x00040000
 #endif
 
-#if defined(_WIN32) && !defined(WINDOWS_PHONE)
-#include "mega/thread/win32thread.h"
-class MegaThread : public mega::Win32Thread {};
-#elif defined(USE_CPPTHREAD)
-#include "mega/thread/cppthread.h"
-class MegaThread : public mega::CppThread {};
-#else
-#include "mega/thread/posixthread.h"
-class MegaThread : public mega::PosixThread {};
-#endif
-
 bool MegaCmdShellCommunicationsNamedPipes::confirmResponse; //TODO: do all this only in parent class
 bool MegaCmdShellCommunicationsNamedPipes::stopListener;
 mega::Thread *MegaCmdShellCommunicationsNamedPipes::listenerThread;


### PR DESCRIPTION
For WIN32, added the option to specify NO_READLINE to use the WinConsole functions from the SDK, which support unicode in the console.
Tab Completions are fetched from megacmd-server.
Added `autocomplete` and `codepage` commands, that work the same way as in `megacli`.
Fixed a possible bug in file version lookup, where local variable `baseNode` was self-referencing in its initialisation.
Protected some thread-based lookups with a mutex, those could be problematic when using WinHttp.