### PR TITLE
Arch - Incremented level of signature trust required for Arch packages.

### DIFF
--- a/build/megacmd/megacmd.install
+++ b/build/megacmd/megacmd.install
@@ -7,7 +7,7 @@ sed -n '1h;1!H;${g;s/###REPO for MEGA###\n.*###END REPO for MEGA###//;p;}' -i /e
 cat >> /etc/pacman.conf <<-EOF
 ###REPO for MEGA###
 [DEB_Arch_Extra]
-SigLevel = Optional TrustAll
+SigLevel = Required TrustedOnly
 Server = https://mega.nz/linux/MEGAsync/Arch_Extra/\$arch
 ###END REPO for MEGA###
 EOF
@@ -37,4 +37,6 @@ Jjiho4rUEW8c1EUPvK8v1jRGwjYED3ihJ6510eblYFPl+6k91OWlScnxuVVAmSn4
 KEY
 
 }
+
+pacman-key --lsign-key 8F208FBF12FEE766AA32AEAF03C3AD3A7F068E5D
 


### PR DESCRIPTION
Changed SigLevel in Mega Arch repo configuration.
Locally sign the imported key.