### PR TITLE
#13560: email block (weak accounts) and sms verification support

### DIFF
--- a/src/client/megacmdclient.cpp
+++ b/src/client/megacmdclient.cpp
@@ -723,6 +723,8 @@ void statechangehandle(string statestring)
     unsigned int width = getNumberOfCols(80);
     if (width > 1 ) width--;
 
+    static string lastMessage;
+
     while (nextstatedelimitpos!=string::npos && statestring.size())
     {
         string newstate = statestring.substr(0,nextstatedelimitpos);
@@ -779,22 +781,27 @@ void statechangehandle(string statestring)
         }
         else if (newstate.compare(0, strlen("message:"), "message:") == 0)
         {
-            string contents = newstate.substr(strlen("message:"));
+            if (lastMessage.compare(newstate)) //to avoid repeating messages
+            {
+                lastMessage = newstate;
 
-            MegaCmdShellCommunications::megaCmdStdoutputing.lock();
-            if (shown_partial_progress)
-            {
-                cerr << endl;
+                string contents = newstate.substr(strlen("message:"));
+
+                MegaCmdShellCommunications::megaCmdStdoutputing.lock();
+                if (shown_partial_progress)
+                {
+                    cerr << endl;
+                }
+                if (contents.find("-----") != 0)
+                {
+                    printCenteredContentsCerr(contents, width);
+                }
+                else
+                {
+                    cerr << endl <<  contents << endl;
+                }
+                MegaCmdShellCommunications::megaCmdStdoutputing.unlock();
             }
-            if (contents.find("-----") != 0)
-            {
-                printCenteredContentsCerr(contents, width);
-            }
-            else
-            {
-                cerr << endl <<  contents << endl;
-            }
-            MegaCmdShellCommunications::megaCmdStdoutputing.unlock();
         }
         else if (newstate.compare(0, strlen("clientID:"), "clientID:") == 0)
         {

--- a/src/listeners.cpp
+++ b/src/listeners.cpp
@@ -167,7 +167,12 @@ void MegaCmdGlobalListener::onEvent(MegaApi *api, MegaEvent *event)
 {
     if (event->getType() == MegaEvent::EVENT_ACCOUNT_BLOCKED)
     {
-        setBlocked(event->getNumber() != MegaApi::ACCOUNT_NOT_BLOCKED); //this should be true always
+        if (getBlocked() == event->getNumber())
+        {
+            LOG_debug << " receivied EVENT_ACCOUNT_BLOCKED: number = " << event->getNumber();
+            return;
+        }
+        setBlocked(event->getNumber()); //this should be true always
 
         switch (event->getNumber())
         {

--- a/src/listeners.h
+++ b/src/listeners.h
@@ -23,14 +23,17 @@
 #include "megacmdsandbox.h"
 
 namespace megacmd {
+class MegaCmdSandbox;
+
 class MegaCmdListener : public mega::SynchronousRequestListener
 {
 private:
     float percentFetchnodes;
     bool alreadyFinished;
-    int clientID;
 
 public:
+    int clientID;
+
     MegaCmdListener(mega::MegaApi *megaApi, mega::MegaRequestListener *listener = NULL, int clientID=-1);
     virtual ~MegaCmdListener();
 
@@ -171,6 +174,8 @@ class MegaCmdGlobalListener : public mega::MegaGlobalListener
 private:
     MegaCMDLogger *loggerCMD;
     MegaCmdSandbox *sandboxCMD;
+
+    std::atomic_bool ongoing;
 
 public:
     MegaCmdGlobalListener(MegaCMDLogger *logger, MegaCmdSandbox *sandboxCMD);

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -318,10 +318,10 @@ void broadcastMessage(string message, bool keepIfNoListeners)
     {
         s += "message:";
         s+=message;
-
+        string unalteredCopy(s);
         if (!cm->informStateListeners(s) && keepIfNoListeners)
         {
-            appendGreetingStatusFirstListener(s);
+            appendGreetingStatusFirstListener(unalteredCopy);
         }
     }
 }
@@ -4025,7 +4025,10 @@ void megacmd()
                 s+=dynamicprompt;
                 s+=(char)0x1F;
 
-                cmdexecuter->checkAndInformPSA(inf);
+                if (!sandboxCMD->getReasonblocked().size())
+                {
+                    cmdexecuter->checkAndInformPSA(inf);
+                }
 
                 cm->informStateListener(inf,s);
             }
@@ -4742,6 +4745,7 @@ int main(int argc, char* argv[])
 
     sandboxCMD = new MegaCmdSandbox();
     cmdexecuter = new MegaCmdExecuter(api, loggerCMD, sandboxCMD);
+    sandboxCMD->cmdexecuter = cmdexecuter;
 
     megaCmdGlobalListener = new MegaCmdGlobalListener(loggerCMD, sandboxCMD);
     megaCmdMegaListener = new MegaCmdMegaListener(api, NULL, sandboxCMD);

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -147,7 +147,7 @@ string dynamicprompt = "MEGA CMD> ";
 static prompttype prompt = COMMAND;
 
 static std::atomic_bool loginInAtStartup(false);
-static std::atomic_bool blocked(false);
+static std::atomic<int> blocked(0);
 
 time_t lastTimeCheckBlockStatus = 0;
 
@@ -4552,7 +4552,7 @@ void setloginInAtStartup(bool value)
 
 void unblock()
 {
-    setBlocked(false);
+    setBlocked(0);
     sandboxCMD->setReasonblocked("");
     broadcastMessage("Your account is not longer blocked");
     if (!api->isFilesystemAvailable())
@@ -4564,14 +4564,17 @@ void unblock()
     }
 }
 
-void setBlocked(bool value)
+void setBlocked(int value)
 {
-    blocked = value;
-    updatevalidCommands();
-    cmdexecuter->updateprompt();
+    if (blocked != value)
+    {
+        blocked = value;
+        updatevalidCommands();
+        cmdexecuter->updateprompt();
+    }
 }
 
-bool getBlocked()
+int getBlocked()
 {
     return blocked;
 }

--- a/src/megacmd.h
+++ b/src/megacmd.h
@@ -121,8 +121,8 @@ void removeGreetingStatusAllListener(const std::string &msj);
 
 
 void setloginInAtStartup(bool value);
-void setBlocked(bool value);
-bool getBlocked();
+void setBlocked(int value);
+int getBlocked();
 void unblock();
 bool getloginInAtStartup();
 void updatevalidCommands();

--- a/src/megacmd.h
+++ b/src/megacmd.h
@@ -121,7 +121,12 @@ void removeGreetingStatusAllListener(const std::string &msj);
 
 
 void setloginInAtStartup(bool value);
+void setBlocked(bool value);
+bool getBlocked();
+void unblock();
 bool getloginInAtStartup();
+void updatevalidCommands();
+void reset();
 
 /**
  * @brief A class to ensure clients are properly informed of login in situations

--- a/src/megacmdcommonutils.cpp
+++ b/src/megacmdcommonutils.cpp
@@ -532,102 +532,106 @@ string getRightAlignedString(const string origin, unsigned int minsize)
 void printCenteredLine(OUTSTREAMTYPE &os, string msj, unsigned int width, bool encapsulated)
 {
     unsigned int msjsize = getstringutf8size(msj);
+    bool overflowed = false;
     if (msjsize>width)
     {
+        overflowed = true;
         width = unsigned(msjsize);
     }
-    if (encapsulated)
+    if (encapsulated && !overflowed)
         os << "|";
     for (unsigned int i = 0; i < (width-msjsize)/2; i++)
         os << " ";
     os << msj;
     for (unsigned int i = 0; i < (width-msjsize)/2 + (width-msjsize)%2 ; i++)
         os << " ";
-    if (encapsulated)
+    if (encapsulated && !overflowed)
         os << "|";
     os << endl;
 }
 
 void printCenteredContents(OUTSTREAMTYPE &os, string msj, unsigned int width, bool encapsulated)
 {
-    string headfoot = " ";
-    headfoot.append(width, '-');
-    unsigned int msjsize = getstringutf8size(msj);
+     string headfoot = " ";
+     headfoot.append(width, '-');
+     unsigned int msjsize = getstringutf8size(msj);
 
-    bool printfooter = false;
+     bool printfooter = false;
 
-    if (msj.size())
-    {
-        string header;
-        if (msj.at(0) == '<')
-        {
-            size_t possenditle = msj.find(">");
-            if (width >= 2 && possenditle < (width -2))
-            {
-                header.append(" ");
-                header.append((width - possenditle ) / 2, '-');
-                header.append(msj.substr(0,possenditle+1));
-                header.append(width - getstringutf8size(header) + 1, '-');
-                msj = msj.substr(possenditle + 1);
-            }
-        }
-        if (header.size() || encapsulated)
-        {
-            os << (header.size()?header:headfoot) << endl;
-            printfooter = true;
-        }
-    }
+     if (msj.size())
+     {
+         string header;
+         if (msj.at(0) == '<')
+         {
+             size_t possenditle = msj.find(">");
+             if (width >= 2 && possenditle < (width -2))
+             {
+                 header.append(" ");
+                 header.append((width - possenditle ) / 2, '-');
+                 header.append(msj.substr(0,possenditle+1));
+                 header.append(width - getstringutf8size(header) + 1, '-');
+                 msj = msj.substr(possenditle + 1);
+             }
+         }
+         if (header.size() || encapsulated)
+         {
+             os << (header.size()?header:headfoot) << endl;
+             printfooter = true;
+         }
+     }
 
-    size_t possepnewline = msj.find("\n");
-    size_t possep = msj.find(" ");
+     size_t possepnewline = msj.find("\n");
+     size_t possep = msj.find(" ");
 
-    if (possepnewline != string::npos && possepnewline < width)
-    {
-        possep = possepnewline;
-    }
-    size_t possepprev = possep;
+     if (possepnewline != string::npos && possepnewline < width)
+     {
+         possep = possepnewline;
+     }
+     size_t possepprev = possep;
 
 
-    while (msj.size())
-    {
+     while (msj.size())
+     {
 
-        if (possepnewline != string::npos && possepnewline <= width)
-        {
-            possep = possepnewline;
-            possepprev = possep;
-        }
-        else
-        {
-            while (possep < width && possep != string::npos)
-            {
-                possepprev = possep;
-                possep = msj.find_first_of(" ", possep+1);
-            }
-        }
+         if (possepnewline != string::npos && possepnewline <= width)
+         {
+             possep = possepnewline;
+             possepprev = possep;
+         }
+         else
+         {
+             while (possep < width && possep != string::npos)
+             {
+                 possepprev = possep;
+                 possep = msj.find_first_of(" ", possep+1);
+             }
+         }
 
-        if (possep == string::npos)
-        {
-            printCenteredLine(os, msj, width, encapsulated);
-            break;
-        }
-        else
-        {
-            printCenteredLine(os, msj.substr(0,possepprev), width, encapsulated);
-            if (possepprev < (msj.size() - 1))
-            {
-                msj = msj.substr(possepprev+1);
-                possepnewline = msj.find("\n");
-            }
-            else
-            {
-                break;
-            }
-        }
-    }
-    if (printfooter)
-    {
-        os << headfoot << endl;
-    }
+         if (possepprev == string::npos || (possep == string::npos && msj.size() <= width))
+         {
+             printCenteredLine(os, msj, width, encapsulated);
+             break;
+         }
+         else
+         {
+             printCenteredLine(os, msj.substr(0,possepprev), width, encapsulated);
+             if (possepprev < (msj.size() - 1))
+             {
+                 msj = msj.substr(possepprev + 1);
+                 possepnewline = msj.find("\n");
+                 possep = msj.find(" ");
+                 possepprev = possep;
+             }
+             else
+             {
+                 break;
+             }
+         }
+     }
+     if (printfooter)
+     {
+         os << headfoot << endl;
+     }
 }
 
 void printCenteredLine(string msj, unsigned int width, bool encapsulated)

--- a/src/megacmdcommonutils.h
+++ b/src/megacmdcommonutils.h
@@ -86,7 +86,7 @@ static std::vector<std::string> localfolderpatterncommands {"lcd"};
 
 static std::vector<std::string> emailpatterncommands {"invite", "signup", "ipc", "users"};
 
-static std::vector<std::string> loginInValidCommands { "log", "debug", "speedlimit","help", "logout", "version", "quit",
+static std::vector<std::string> loginInValidCommands { "log", "debug", "speedlimit", "help", "logout", "version", "quit",
                             "clear", "https", "exit", "errorcode", "proxy"
 #if defined(_WIN32) && defined(NO_READLINE)
                              , "autocomplete", "codepage"

--- a/src/megacmdexecuter.cpp
+++ b/src/megacmdexecuter.cpp
@@ -1009,7 +1009,8 @@ bool MegaCmdExecuter::checkNoErrors(MegaError *error, string message)
     setCurrentOutCode(error->getErrorCode());
     if (error->getErrorCode() == MegaError::API_EBLOCKED)
     {
-        LOG_err << "Failed to " << message << ". Account blocked. Reason: " << sandboxCMD->reasonblocked;
+        auto reason = sandboxCMD->getReasonblocked();
+        LOG_err << "Failed to " << message << ". Account blocked." <<( reason.empty()?"":" Reason: "+reason);
     }
     else if (error->getErrorCode() == MegaError::API_EOVERQUOTA && sandboxCMD->storageStatus == MegaApi::STORAGE_STATE_RED)
     {
@@ -2288,27 +2289,20 @@ bool MegaCmdExecuter::actUponFetchNodes(MegaApi *api, SynchronousRequestListener
         }
     }
 
-    if (checkNoErrors(srl->getError(), "fetch nodes"))
+    if (srl->getError()->getErrorCode() == MegaError::API_EBLOCKED)
+    {
+        LOG_verbose << " EBLOCKED after fetch nodes. quering for reason...";
+
+        MegaCmdListener *megaCmdListener = new MegaCmdListener(api, NULL);
+        api->whyAmIBlocked(megaCmdListener); //This shall cause event that sets reasonblocked
+        megaCmdListener->wait();
+        auto reason = sandboxCMD->getReasonblocked();
+        LOG_err << "Failed to fetch nodes. Account blocked." <<( reason.empty()?"":" Reason: "+reason);
+    }
+    else if (checkNoErrors(srl->getError(), "fetch nodes"))
     {
         LOG_verbose << "actUponFetchNodes ok";
-        api->enableTransferResumption();
 
-        MegaNode *cwdNode = ( cwd == UNDEF ) ? NULL : api->getNodeByHandle(cwd);
-        if (( cwd == UNDEF ) || !cwdNode)
-        {
-            MegaNode *rootNode = srl->getApi()->getRootNode();
-            cwd = rootNode->getHandle();
-            delete rootNode;
-        }
-        if (cwdNode)
-        {
-            delete cwdNode;
-        }
-
-        setloginInAtStartup(false); //to enable all commands before giving clients the green light!
-        informStateListeners("loged:"); // tell the clients login ended, before providing them the first prompt
-        updateprompt(api, cwd);
-        LOG_debug << " Fetch nodes correctly";
         return true;
     }
     return false;
@@ -2407,181 +2401,10 @@ int MegaCmdExecuter::actUponLogin(SynchronousRequestListener *srl, int timeout)
 #endif
 
         LOG_info << "Fetching nodes ... ";
-        srl->getApi()->fetchNodes(srl);
-        actUponFetchNodes(api, srl, timeout);
-        MegaUser *u = api->getMyUser();
-        if (u)
-        {
-            LOG_info << "Login complete as " << u->getEmail();
-            delete u;
-        }
+        MegaApi *api = srl->getApi();
+        int clientID = static_cast<MegaCmdListener*>(srl)->clientID;
 
-        if (ConfigurationManager::getConfigurationValue("ask4storage", true))
-        {
-            ConfigurationManager::savePropertyValue("ask4storage",false);
-            MegaCmdListener *megaCmdListener = new MegaCmdListener(NULL);
-            api->getAccountDetails(megaCmdListener);
-            megaCmdListener->wait();
-            // we don't call getAccountDetails on startup always: we ask on first login (no "ask4storage") or previous state was STATE_RED | STATE_ORANGE
-            // if we were green, don't need to ask: if there are changes they will be received via action packet indicating STATE_CHANGE
-        }
-
-        checkAndInformPSA(NULL); // this needs broacasting in case there's another Shell running.
-                                 // no need to enforce, because time since last check should has been restored
-
-#ifdef ENABLE_BACKUPS
-        mtxBackupsMap.lock();
-        if (ConfigurationManager::configuredBackups.size())
-        {
-            LOG_info << "Restablishing backups ... ";
-            unsigned int i=0;
-            for (map<string, backup_struct *>::iterator itr = ConfigurationManager::configuredBackups.begin();
-                 itr != ConfigurationManager::configuredBackups.end(); ++itr, i++)
-            {
-                backup_struct *thebackup = itr->second;
-
-                MegaNode * node = api->getNodeByHandle(thebackup->handle);
-                if (establishBackup(thebackup->localpath, node, thebackup->period, thebackup->speriod, thebackup->numBackups))
-                {
-                    thebackup->failed = false;
-                    const char *nodepath = api->getNodePath(node);
-                    LOG_debug << "Succesfully resumed backup: " << thebackup->localpath << " to " << nodepath;
-                    delete []nodepath;
-                }
-                else
-                {
-                    thebackup->failed = true;
-                    char *nodepath = api->getNodePath(node);
-                    LOG_err << "Failed to resume backup: " << thebackup->localpath << " to " << nodepath;
-                    delete []nodepath;
-                }
-
-                delete node;
-            }
-
-            ConfigurationManager::saveBackups(&ConfigurationManager::configuredBackups);
-        }
-        mtxBackupsMap.unlock();
-#endif
-
-#ifdef HAVE_LIBUV
-        // restart webdav
-        int port = ConfigurationManager::getConfigurationValue("webdav_port", -1);
-        if (port != -1)
-        {
-            bool localonly = ConfigurationManager::getConfigurationValue("webdav_localonly", -1);
-            bool tls = ConfigurationManager::getConfigurationValue("webdav_tls", false);
-            string pathtocert, pathtokey;
-            pathtocert = ConfigurationManager::getConfigurationSValue("webdav_cert");
-            pathtokey = ConfigurationManager::getConfigurationSValue("webdav_key");
-
-            api->httpServerEnableFolderServer(true);
-            if (api->httpServerStart(localonly, port, tls, pathtocert.c_str(), pathtokey.c_str()))
-            {
-                list<string> servedpaths = ConfigurationManager::getConfigurationValueList("webdav_served_locations");
-                bool modified = false;
-
-                for ( std::list<string>::iterator it = servedpaths.begin(); it != servedpaths.end(); ++it)
-                {
-                    string pathToServe = *it;
-                    if (pathToServe.size())
-                    {
-                        MegaNode *n = nodebypath(pathToServe.c_str());
-                        if (n)
-                        {
-                            char *l = api->httpServerGetLocalWebDavLink(n);
-                            char *actualNodePath = api->getNodePath(n);
-                            LOG_debug << "Serving via webdav: " << actualNodePath << ": " << l;
-
-                            if (pathToServe != actualNodePath)
-                            {
-                                it = servedpaths.erase(it);
-                                servedpaths.insert(it,string(actualNodePath));
-                                modified = true;
-                            }
-                            delete []l;
-                            delete []actualNodePath;
-                            delete n;
-                        }
-                        else
-                        {
-                            LOG_warn << "Could no find location to server via webdav: " << pathToServe;
-                        }
-                    }
-                }
-                if (modified)
-                {
-                    ConfigurationManager::savePropertyValueList("webdav_served_locations", servedpaths);
-                }
-
-                LOG_info << "Webdav server restored due to saved configuration";
-            }
-            else
-            {
-                LOG_err << "Failed to initialize WEBDAV server. Ensure the port is free.";
-            }
-        }
-
-        //ftp
-        // restart ftp
-        int portftp = ConfigurationManager::getConfigurationValue("ftp_port", -1);
-
-        if (portftp != -1)
-        {
-            bool localonly = ConfigurationManager::getConfigurationValue("ftp_localonly", -1);
-            bool tls = ConfigurationManager::getConfigurationValue("ftp_tls", false);
-            string pathtocert, pathtokey;
-            pathtocert = ConfigurationManager::getConfigurationSValue("ftp_cert");
-            pathtokey = ConfigurationManager::getConfigurationSValue("ftp_key");
-            int dataPortRangeBegin = ConfigurationManager::getConfigurationValue("ftp_port_data_begin", 1500);
-            int dataPortRangeEnd = ConfigurationManager::getConfigurationValue("ftp_port_data_end", 1500+100);
-
-            if (api->ftpServerStart(localonly, portftp, dataPortRangeBegin, dataPortRangeEnd, tls, pathtocert.c_str(), pathtokey.c_str()))
-            {
-                list<string> servedpaths = ConfigurationManager::getConfigurationValueList("ftp_served_locations");
-                bool modified = false;
-
-                for ( std::list<string>::iterator it = servedpaths.begin(); it != servedpaths.end(); ++it)
-                {
-                    string pathToServe = *it;
-                    if (pathToServe.size())
-                    {
-                        MegaNode *n = nodebypath(pathToServe.c_str());
-                        if (n)
-                        {
-                            char *l = api->ftpServerGetLocalLink(n);
-                            char *actualNodePath = api->getNodePath(n);
-                            LOG_debug << "Serving via ftp: " << pathToServe << ": " << l << ". Data Channel Port Range: " << dataPortRangeBegin << "-" << dataPortRangeEnd;
-
-                            if (pathToServe != actualNodePath)
-                            {
-                                it = servedpaths.erase(it);
-                                servedpaths.insert(it,string(actualNodePath));
-                                modified = true;
-                            }
-                            delete []l;
-                            delete []actualNodePath;
-                            delete n;
-                        }
-                        else
-                        {
-                            LOG_warn << "Could no find location to server via ftp: " << pathToServe;
-                        }
-                    }
-                }
-                if (modified)
-                {
-                    ConfigurationManager::savePropertyValueList("ftp_served_locations", servedpaths);
-                }
-
-                LOG_info << "FTP server restored due to saved configuration";
-            }
-            else
-            {
-                LOG_err << "Failed to initialize FTP server. Ensure the port is free.";
-            }
-        }
-#endif
+        fetchNodes(api, clientID);
     }
 
 #if defined(_WIN32) || defined(__APPLE__)
@@ -2633,6 +2456,213 @@ int MegaCmdExecuter::actUponLogin(SynchronousRequestListener *srl, int timeout)
 
 #endif
     return srl->getError()->getErrorCode();
+}
+
+void MegaCmdExecuter::fetchNodes(MegaApi *api, int clientID)
+{
+    MegaCmdListener * megaCmdListener = new MegaCmdListener(api, NULL, clientID);
+    api->fetchNodes(megaCmdListener);
+    if (!actUponFetchNodes(api, megaCmdListener))
+    {
+        //Ideally we should enter an state that indicates that we are not fully logged.
+        //Specially when the account is blocked
+        return;
+    }
+
+    // This is the actual acting upon fetch nodes ended correctly:
+
+    api->enableTransferResumption();
+
+    MegaNode *cwdNode = ( cwd == UNDEF ) ? NULL : api->getNodeByHandle(cwd);
+    if (( cwd == UNDEF ) || !cwdNode)
+    {
+        MegaNode *rootNode = api->getRootNode();
+        cwd = rootNode->getHandle();
+        delete rootNode;
+    }
+    if (cwdNode)
+    {
+        delete cwdNode;
+    }
+
+    setloginInAtStartup(false); //to enable all commands before giving clients the green light!
+    informStateListeners("loged:"); // tell the clients login ended, before providing them the first prompt
+    updateprompt(api, cwd);
+    LOG_debug << " Fetch nodes correctly";
+
+    MegaUser *u = api->getMyUser();
+    if (u)
+    {
+        LOG_info << "Login complete as " << u->getEmail();
+        delete u;
+    }
+
+    if (ConfigurationManager::getConfigurationValue("ask4storage", true))
+    {
+        ConfigurationManager::savePropertyValue("ask4storage",false);
+        MegaCmdListener *megaCmdListener = new MegaCmdListener(NULL);
+        api->getAccountDetails(megaCmdListener);
+        megaCmdListener->wait();
+        // we don't call getAccountDetails on startup always: we ask on first login (no "ask4storage") or previous state was STATE_RED | STATE_ORANGE
+        // if we were green, don't need to ask: if there are changes they will be received via action packet indicating STATE_CHANGE
+    }
+
+    checkAndInformPSA(NULL); // this needs broacasting in case there's another Shell running.
+    // no need to enforce, because time since last check should has been restored
+
+#ifdef ENABLE_BACKUPS
+    mtxBackupsMap.lock();
+    if (ConfigurationManager::configuredBackups.size())
+    {
+        LOG_info << "Restablishing backups ... ";
+        unsigned int i=0;
+        for (map<string, backup_struct *>::iterator itr = ConfigurationManager::configuredBackups.begin();
+             itr != ConfigurationManager::configuredBackups.end(); ++itr, i++)
+        {
+            backup_struct *thebackup = itr->second;
+
+            MegaNode * node = api->getNodeByHandle(thebackup->handle);
+            if (establishBackup(thebackup->localpath, node, thebackup->period, thebackup->speriod, thebackup->numBackups))
+            {
+                thebackup->failed = false;
+                const char *nodepath = api->getNodePath(node);
+                LOG_debug << "Succesfully resumed backup: " << thebackup->localpath << " to " << nodepath;
+                delete []nodepath;
+            }
+            else
+            {
+                thebackup->failed = true;
+                char *nodepath = api->getNodePath(node);
+                LOG_err << "Failed to resume backup: " << thebackup->localpath << " to " << nodepath;
+                delete []nodepath;
+            }
+
+            delete node;
+        }
+
+        ConfigurationManager::saveBackups(&ConfigurationManager::configuredBackups);
+    }
+    mtxBackupsMap.unlock();
+#endif
+
+#ifdef HAVE_LIBUV
+    // restart webdav
+    int port = ConfigurationManager::getConfigurationValue("webdav_port", -1);
+    if (port != -1)
+    {
+        bool localonly = ConfigurationManager::getConfigurationValue("webdav_localonly", -1);
+        bool tls = ConfigurationManager::getConfigurationValue("webdav_tls", false);
+        string pathtocert, pathtokey;
+        pathtocert = ConfigurationManager::getConfigurationSValue("webdav_cert");
+        pathtokey = ConfigurationManager::getConfigurationSValue("webdav_key");
+
+        api->httpServerEnableFolderServer(true);
+        if (api->httpServerStart(localonly, port, tls, pathtocert.c_str(), pathtokey.c_str()))
+        {
+            list<string> servedpaths = ConfigurationManager::getConfigurationValueList("webdav_served_locations");
+            bool modified = false;
+
+            for ( std::list<string>::iterator it = servedpaths.begin(); it != servedpaths.end(); ++it)
+            {
+                string pathToServe = *it;
+                if (pathToServe.size())
+                {
+                    MegaNode *n = nodebypath(pathToServe.c_str());
+                    if (n)
+                    {
+                        char *l = api->httpServerGetLocalWebDavLink(n);
+                        char *actualNodePath = api->getNodePath(n);
+                        LOG_debug << "Serving via webdav: " << actualNodePath << ": " << l;
+
+                        if (pathToServe != actualNodePath)
+                        {
+                            it = servedpaths.erase(it);
+                            servedpaths.insert(it,string(actualNodePath));
+                            modified = true;
+                        }
+                        delete []l;
+                        delete []actualNodePath;
+                        delete n;
+                    }
+                    else
+                    {
+                        LOG_warn << "Could no find location to server via webdav: " << pathToServe;
+                    }
+                }
+            }
+            if (modified)
+            {
+                ConfigurationManager::savePropertyValueList("webdav_served_locations", servedpaths);
+            }
+
+            LOG_info << "Webdav server restored due to saved configuration";
+        }
+        else
+        {
+            LOG_err << "Failed to initialize WEBDAV server. Ensure the port is free.";
+        }
+    }
+
+    //ftp
+    // restart ftp
+    int portftp = ConfigurationManager::getConfigurationValue("ftp_port", -1);
+
+    if (portftp != -1)
+    {
+        bool localonly = ConfigurationManager::getConfigurationValue("ftp_localonly", -1);
+        bool tls = ConfigurationManager::getConfigurationValue("ftp_tls", false);
+        string pathtocert, pathtokey;
+        pathtocert = ConfigurationManager::getConfigurationSValue("ftp_cert");
+        pathtokey = ConfigurationManager::getConfigurationSValue("ftp_key");
+        int dataPortRangeBegin = ConfigurationManager::getConfigurationValue("ftp_port_data_begin", 1500);
+        int dataPortRangeEnd = ConfigurationManager::getConfigurationValue("ftp_port_data_end", 1500+100);
+
+        if (api->ftpServerStart(localonly, portftp, dataPortRangeBegin, dataPortRangeEnd, tls, pathtocert.c_str(), pathtokey.c_str()))
+        {
+            list<string> servedpaths = ConfigurationManager::getConfigurationValueList("ftp_served_locations");
+            bool modified = false;
+
+            for ( std::list<string>::iterator it = servedpaths.begin(); it != servedpaths.end(); ++it)
+            {
+                string pathToServe = *it;
+                if (pathToServe.size())
+                {
+                    MegaNode *n = nodebypath(pathToServe.c_str());
+                    if (n)
+                    {
+                        char *l = api->ftpServerGetLocalLink(n);
+                        char *actualNodePath = api->getNodePath(n);
+                        LOG_debug << "Serving via ftp: " << pathToServe << ": " << l << ". Data Channel Port Range: " << dataPortRangeBegin << "-" << dataPortRangeEnd;
+
+                        if (pathToServe != actualNodePath)
+                        {
+                            it = servedpaths.erase(it);
+                            servedpaths.insert(it,string(actualNodePath));
+                            modified = true;
+                        }
+                        delete []l;
+                        delete []actualNodePath;
+                        delete n;
+                    }
+                    else
+                    {
+                        LOG_warn << "Could no find location to server via ftp: " << pathToServe;
+                    }
+                }
+            }
+            if (modified)
+            {
+                ConfigurationManager::savePropertyValueList("ftp_served_locations", servedpaths);
+            }
+
+            LOG_info << "FTP server restored due to saved configuration";
+        }
+        else
+        {
+            LOG_err << "Failed to initialize FTP server. Ensure the port is free.";
+        }
+    }
+#endif
 }
 
 void MegaCmdExecuter::actUponLogout(SynchronousRequestListener *srl, bool keptSession, int timeout)

--- a/src/megacmdexecuter.cpp
+++ b/src/megacmdexecuter.cpp
@@ -2302,7 +2302,7 @@ bool MegaCmdExecuter::actUponFetchNodes(MegaApi *api, SynchronousRequestListener
         api->whyAmIBlocked(megaCmdListener); //This shall cause event that sets reasonblocked
         megaCmdListener->wait();
         auto reason = sandboxCMD->getReasonblocked();
-        LOG_err << "Failed to fetch nodes. Account blocked." <<( reason.empty()?"":" Reason: "+reason);
+        LOG_warn << "Failed to fetch nodes. Account blocked." <<( reason.empty()?"":" Reason: "+reason);
     }
     else if (checkNoErrors(srl->getError(), "fetch nodes"))
     {

--- a/src/megacmdexecuter.h
+++ b/src/megacmdexecuter.h
@@ -24,6 +24,10 @@
 #include "listeners.h"
 
 namespace megacmd {
+class MegaCmdSandbox;
+class MegaCmdMultiTransferListener;
+class MegaCmdGlobalTransferListener;
+
 class MegaCmdExecuter
 {
 private:
@@ -197,6 +201,7 @@ public:
 #endif
     bool printUserAttribute(int a, std::string user, bool onlylist = false);
     bool setProxy(const std::string &url, const std::string &username, const std::string &password, int proxyType);
+    void fetchNodes(mega::MegaApi *api, int clientID = -27);
 };
 
 }//end namespace

--- a/src/megacmdexecuter.h
+++ b/src/megacmdexecuter.h
@@ -55,7 +55,6 @@ private:
     //delete confirmation
     std::vector<mega::MegaNode *> nodesToConfirmDelete;
 
-    void updateprompt(mega::MegaApi *api, mega::MegaHandle handle);
 
     std::string getNodePathString(mega::MegaNode *n);
 
@@ -68,6 +67,8 @@ public:
 
     MegaCmdExecuter(mega::MegaApi *api, MegaCMDLogger *loggerCMD, MegaCmdSandbox *sandboxCMD);
     ~MegaCmdExecuter();
+
+    void updateprompt(mega::MegaApi *api = nullptr);
 
     // nodes browsing
     void listtrees();
@@ -201,7 +202,7 @@ public:
 #endif
     bool printUserAttribute(int a, std::string user, bool onlylist = false);
     bool setProxy(const std::string &url, const std::string &username, const std::string &password, int proxyType);
-    void fetchNodes(mega::MegaApi *api, int clientID = -27);
+    void fetchNodes(mega::MegaApi *api = nullptr, int clientID = -27);
 };
 
 }//end namespace

--- a/src/megacmdsandbox.h
+++ b/src/megacmdsandbox.h
@@ -37,6 +37,8 @@ private:
     bool reasonPending = false;
     std::promise<std::string> reasonPromise;
 
+    void doSetReasonBlocked(const std::string &value);
+
 public:
     bool istemporalbandwidthvalid;
     long long temporalbandwidth;
@@ -48,7 +50,6 @@ public:
     ::mega::m_time_t timeOfPSACheck;
     int lastPSAnumreceived;
 
-    bool accounthasbeenblocked;
     int storageStatus;
     long long receivedStorageSum;
     long long totalStorage;

--- a/src/megacmdsandbox.h
+++ b/src/megacmdsandbox.h
@@ -22,12 +22,21 @@
 #include <mega.h>
 #include <ctime>
 #include <string>
+#include <future>
+#include "megacmdexecuter.h"
 
 namespace megacmd {
+class MegaCmdExecuter;
+
 class MegaCmdSandbox
 {
 private:
     bool overquota;
+    std::mutex reasonBlockedMutex;
+    std::string reasonblocked;
+    bool reasonPending = false;
+    std::promise<std::string> reasonPromise;
+
 public:
     bool istemporalbandwidthvalid;
     long long temporalbandwidth;
@@ -40,15 +49,24 @@ public:
     int lastPSAnumreceived;
 
     bool accounthasbeenblocked;
-    std::string reasonblocked;
     int storageStatus;
     long long receivedStorageSum;
     long long totalStorage;
+
+    MegaCmdExecuter * cmdexecuter = nullptr;
+
 public:
     MegaCmdSandbox();
     bool isOverquota() const;
     void setOverquota(bool value);
     void resetSandBox();
+
+    std::string getReasonblocked();
+    void setReasonPendingPromise();
+    void setReasonblocked(const std::string &value);
+    void setPromisedReasonblocked(const std::string &value);
+
+
 };
 
 }//end namespace

--- a/src/megacmdshell/megacmdshell.cpp
+++ b/src/megacmdshell/megacmdshell.cpp
@@ -309,6 +309,7 @@ void statechangehandle(string statestring)
 #ifndef NO_READLINE
                     if (prompt == COMMAND && promtpLogReceivedBool)
                     {
+                        std::lock_guard<std::mutex> g(mutexPrompt);
                         redisplay_prompt();
                     }
 #endif

--- a/src/megacmdshell/megacmdshell.h
+++ b/src/megacmdshell/megacmdshell.h
@@ -43,6 +43,8 @@ void printprogress(long long completed, long long total, const char *title = "TR
 
 void changeprompt(const char *newprompt, bool redisplay = false);
 
+void redisplay_prompt();
+
 const char * getUsageStr(const char *command);
 
 void unescapeifRequired(std::string &what);


### PR DESCRIPTION
- store reason blocked with special care for
ACCOUNT_BLOCKED_VERIFICATION_SMS, that requires to queue a request to
get a session-transferred URL within a new thread. Use a promise so that
the thread that reads the reason waits for it to be set.
- fix issue with doubled separator chars in greetings messages
- do not ask for psa at first client arrival if blocked
- refactor after fecth node code & avoid some actions when failed!
- enforce a whyamiblocked after fetchnodes resulted in blocked (might
not be 100% required though)