### PR TITLE
#15740: Link cryptopp statically for Ubuntu >= 19.10

### DIFF
--- a/build/megacmd/debian.rules
+++ b/build/megacmd/debian.rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 CPPFLAGS := $(shell cat /etc/issue | grep "Ubuntu 1[2357]\|Debian.* 7\|Ubuntu 1[46].10" >/dev/null && echo "$$CPPFLAGS -DMEGACMD_DEPRECATED_OS" || echo "")
+FCRYPTOPP := $(shell cat /etc/issue | grep "Ubuntu 19.10\|Ubuntu [2-9][0-9]" >/dev/null && echo "-q" || echo " ")
+WCRYPTOPP := $(shell cat /etc/issue | grep "Ubuntu 19.10\|Ubuntu [2-9][0-9]" >/dev/null && echo "--with-cryptopp=$(CURDIR)/deps" || echo " ")
 FMEDIAINFO := $(shell dpkg -l | grep mediainfo >/dev/null && echo "-i" || echo " ")
 WMEDIAINFO := $(shell dpkg -l | grep mediainfo >/dev/null && echo " " || echo "--with-libmediainfo=$(CURDIR)/deps --with-libzen=$(CURDIR)/deps")
 FULLREQS := $(shell cat /etc/issue | grep "Ubuntu 12.04" >/dev/null && echo "" || echo '-DREQUIRE_HAVE_FFMPEG -DREQUIRE_HAVE_LIBUV -DREQUIRE_USE_MEDIAINFO -DREQUIRE_USE_PCRE')
@@ -16,12 +18,12 @@ build-stamp:
 	#build dependencies into folder deps
 	mkdir deps || :
 	bash -x ./sdk/contrib/build_sdk.sh -o archives \
-	  -g -b $(FMEDIAINFO) -l -c -s -u -v -a -z -I -p deps/
+	  -g -b $(FMEDIAINFO) $(FCRYPTOPP) -l -c -s -u -v -a -z -I -p deps/
 
 	CPPFLAGS="$(CPPFLAGS) $(FULLREQS)" ./configure --without-libraw --disable-shared --enable-static --disable-silent-rules \
 	  --disable-curl-checks --with-sodium=$(CURDIR)/deps --with-libuv=$(CURDIR)/deps --with-pcre \
 	  --with-curl=$(CURDIR)/deps --with-freeimage=$(CURDIR)/deps --with-readline=$(CURDIR)/deps \
-	  --with-termcap=$(CURDIR)/deps --prefix=$(CURDIR)/deps --disable-examples $(WMEDIAINFO)
+	  --with-termcap=$(CURDIR)/deps $(WCRYPTOPP) --prefix=$(CURDIR)/deps --disable-examples $(WMEDIAINFO)
 
 	make
 	echo "fs.inotify.max_user_watches = 524288" > 100-megacmd-inotify-limit.conf


### PR DESCRIPTION
Link statically with a newer version of cryptopp that fix crashes in Ubuntu 19.10 and 20.04