### PR TITLE
#15731: send event before proceeding to an auto-update, and also after update…

### DIFF
--- a/src/megacmd.h
+++ b/src/megacmd.h
@@ -46,6 +46,10 @@ namespace megacmd {
 // Events
 const int MCMD_EVENT_UPDATE_ID = 98900;
 const char MCMD_EVENT_UPDATE_MESSAGE[] = "MEGAcmd update";
+const int MCMD_EVENT_UPDATE_START_ID = 98901;
+const char MCMD_EVENT_UPDATE_START_MESSAGE[] = "MEGAcmd auto-update start";
+const int MCMD_EVENT_UPDATE_RESTART_ID = 98902;
+const char MCMD_EVENT_UPDATE_RESTART_MESSAGE[] = "MEGAcmd updated requiring restart";
 
 typedef struct sync_struct
 {

--- a/src/megacmdversion.h
+++ b/src/megacmdversion.h
@@ -25,6 +25,7 @@ const char * const megacmdchangelog =
         "Support for blocked accounts with instructions to unblock them""\n"
         "Fix crash in libcryptopp for Ubuntu 19.10 and onwards""\n"
         "Fix issues with failed transfers""\n"
+        "Fix trailing separator issue for local path in \"put\"""\n"
         "Speed up sync engine startup for windows""\n"
         "Other fixes & adjustments"
         ;


### PR DESCRIPTION
…d (before restarting)

manual updates start stays unaccounted, since it initializes the
updating process without knowing if that will actually entail an update

- enforce LOG_LEVEL_DEBUG when copmiling in DEBUG
- add missing changelog line