### PR TITLE
Misspell correction

### DIFF
--- a/src/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
+++ b/src/megacmdshell/megacmdshellcommunicationsnamedpipes.cpp
@@ -783,7 +783,7 @@ int MegaCmdShellCommunicationsNamedPipes::listenToStateChanges(int receiveNamedP
             {
                 if (!stopListener && !updating)
                 {
-                    cerr << "ERROR reading output (state change): The sever problably exited."<< endl;
+                    cerr << "ERROR reading output (state change): The server probably exited."<< endl;
                 }
             }
             else


### PR DESCRIPTION
Misspell correction from "ERROR reading output (state change): The sever problably exited." to "ERROR reading output (state change): The server probably exited."