### PR TITLE
Store config data in $XDG_DATA_HOME/megaCmd instead of ~/.megaCmd

### DIFF
--- a/contrib/docs/DEBUG.md
+++ b/contrib/docs/DEBUG.md
@@ -32,7 +32,8 @@ export PATH=/Applications/MEGAcmd.app/Contents/MacOS:$PATH
 
 ### Linux
 By default, whenever MEGAcmdServer is executed, it will log the output into 
-$HOME/.megaCmd/megacmdserver.log. 
+`$XDG_DATA_HOME/megaCmd/megacmdserver.log` (or `$HOME/.megaCmd/megacmdserver.log`
+if `$XDG_DATA_HOME` is not set).
 
 If you want to launch it manually execute in a terminal:
 

--- a/src/configurationmanager.cpp
+++ b/src/configurationmanager.cpp
@@ -104,29 +104,39 @@ void ConfigurationManager::loadConfigDir()
         }
     }
 #else
-    const char *homedir = NULL;
-
-    homedir = getenv("HOME");
-    if (!homedir)
-    {
-        struct passwd pd;
-        struct passwd* pwdptr = &pd;
-        struct passwd* tempPwdPtr;
-        char pwdbuffer[200];
-        int pwdlinelen = sizeof( pwdbuffer );
-
-        if (( getpwuid_r(22, pwdptr, pwdbuffer, pwdlinelen, &tempPwdPtr)) != 0)
-        {
-            LOG_fatal << "Couldnt get HOME folder";
-            return;
-        }
-        else
-        {
-            homedir = pwdptr->pw_dir;
-        }
-    }
     stringstream sconfigDir;
-    sconfigDir << homedir << "/" << ".megaCmd";
+    const char *xdg_data_home = NULL;
+
+    xdg_data_home = getenv("XDG_DATA_HOME");
+    if (xdg_data_home)
+    {
+        sconfigDir << xdg_data_home << "/" << "megaCmd";
+    }
+    else
+    {
+        const char *homedir = NULL;
+
+        homedir = getenv("HOME");
+        if (!homedir)
+        {
+            struct passwd pd;
+            struct passwd* pwdptr = &pd;
+            struct passwd* tempPwdPtr;
+            char pwdbuffer[200];
+            int pwdlinelen = sizeof( pwdbuffer );
+
+            if (( getpwuid_r(22, pwdptr, pwdbuffer, pwdlinelen, &tempPwdPtr)) != 0)
+            {
+                LOG_fatal << "Couldnt get HOME folder";
+                return;
+            }
+            else
+            {
+                homedir = pwdptr->pw_dir;
+            }
+        }
+        sconfigDir << homedir << "/" << ".megaCmd";
+    }
     configFolder = sconfigDir.str();
 #endif
 

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -2939,7 +2939,7 @@ string getHelpStr(const char *command)
         os << "                                                         "  << "\t" << "Note: you can still get the information from the db using OJBECT_ID." << endl;
         os << "                                                         "  << "\t" << "Default=40000" << endl;
         os << " downloads_tracking_max_finished_in_memory_low_threshold"  << "\t" << "When pruning is executed it will clean until this threshold. Default=20000" << endl;
-        os << " downloads_db_path"  << "\t" << "Path to store tracking information of downloads. Default: ~/.megaCmd/downloads.db" << endl;
+        os << " downloads_db_path"  << "\t" << "Path to store tracking information of downloads. Default: $XDG_DATA_HOME/megaCmd/downloads.db (or $HOME/.megaCmd/downloads.db if $XDG_DATA_HOME is not set)" << endl;
         os << " downloads_db_io_frequency_ms"  << "\t" << "Frequency in milliseconds to commit pending changes in the database. Default=10000" << endl;
         os << " downloads_db_max_queued_changes"  << "\t" << "Max allowed number of changes to be queued before writting. Default=1000" << endl;
         os << " downloads_cleanslate_enabled"  << "\t" << "If transfers from previous executions will be discarded upon restart. Default=0 (false)" << endl;

--- a/src/megacmdshell/megacmdshellcommunications.cpp
+++ b/src/megacmdshell/megacmdshellcommunications.cpp
@@ -126,31 +126,40 @@ string createAndRetrieveConfigFolder()
     }
     //TODO: create folder (not required currently)
 #else
-    const char *homedir = NULL;
-
-    homedir = getenv("HOME");
-    if (!homedir)
-    {
-        struct passwd pd;
-        struct passwd* pwdptr = &pd;
-        struct passwd* tempPwdPtr;
-        char pwdbuffer[200];
-        int pwdlinelen = sizeof( pwdbuffer );
-
-        if (( getpwuid_r(22, pwdptr, pwdbuffer, pwdlinelen, &tempPwdPtr)) != 0)
-        {
-            cerr << "Couldnt get HOME folder" << endl;
-            return "/tmp";
-        }
-        else
-        {
-            homedir = pwdptr->pw_dir;
-        }
-    }
     stringstream sconfigDir;
-    sconfigDir << homedir << "/" << ".megaCmd";
-    configFolder = sconfigDir.str();
+    const char *xdg_data_home = NULL;
 
+    xdg_data_home = getenv("XDG_DATA_HOME");
+    if (xdg_data_home)
+    {
+        sconfigDir << xdg_data_home << "/" << "megaCmd";
+    }
+    else
+    {
+        const char *homedir = NULL;
+
+        homedir = getenv("HOME");
+        if (!homedir)
+        {
+            struct passwd pd;
+            struct passwd* pwdptr = &pd;
+            struct passwd* tempPwdPtr;
+            char pwdbuffer[200];
+            int pwdlinelen = sizeof( pwdbuffer );
+
+            if (( getpwuid_r(22, pwdptr, pwdbuffer, pwdlinelen, &tempPwdPtr)) != 0)
+            {
+                cerr << "Couldnt get HOME folder" << endl;
+                return "/tmp";
+            }
+            else
+            {
+                homedir = pwdptr->pw_dir;
+            }
+        }
+        sconfigDir << homedir << "/" << ".megaCmd";
+    }
+    configFolder = sconfigDir.str();
 
     struct stat st;
     if (stat(configFolder.c_str(), &st) == -1) {


### PR DESCRIPTION
If `$XDG_DATA_HOME` environment variable is not set, it will fallback to the previous behaviour and use $HOME/.megaCmd.

This is a breaking change, so package maintainers and users should be instructed to move `$HOME/.megaCmd` to `$XDG_DATA_HOME/megaCmd`, if they use XDG directories (most desktop distros use them by default). Or you can implement some auto-migration procedure.

`$XDG_DATA_HOME` defines the base directory relative to which user-specific data files should be stored [1]. On modern Linux systems, applications should follow XDG directories standard and don't clutter $HOME with dot files and directories.

[1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
[2]: https://wiki.archlinux.org/title/XDG_Base_Directory