### PR TITLE
Fix Issue 696 - Slow boot on WLS 22.04

### DIFF
--- a/src/client/megacmd_completion.sh
+++ b/src/client/megacmd_completion.sh
@@ -76,6 +76,6 @@ _megacmd()
 
 	return 0
 }
-for i in $(compgen -ca | grep mega-); do
+for i in $(compgen -ca mega-); do
 	IFS=" " complete -o default -F _megacmd $i
 done


### PR DESCRIPTION
As per https://github.com/meganz/MEGAcmd/issues/696 megaCMD slow down WSL2 boot (Ubuntu 22.04). a proposed fix is https://github.com/meganz/MEGAcmd/issues/696#issuecomment-1339975056