### PR TITLE
Help string typos

### DIFF
--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -2337,7 +2337,7 @@ string getHelpStr(const char *command)
     {
         os << "Shows/Establish default permissions for files and folders created by MEGAcmd." << endl;
         os << endl;
-        os << "Permissions are unix-like permissions, with 3 numbers: one for owner, one for group and one for others" << endl;
+        os << "Permissions are Unix-like permissions, with 3 numbers: one for owner, one for group and one for others" << endl;
         os << "Options:" << endl;
         os << " --files" << "\t" << "To show/set files default permissions." << endl;
         os << " --folders" << "\t" << "To show/set folders default permissions." << endl;

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -2344,7 +2344,7 @@ string getHelpStr(const char *command)
         os << " --s XXX" << "\t" << "To set new permissions for newly created files/folder. " << endl;
         os << "        " << "\t" << " Notice that for files minimum permissions is 600," << endl;
         os << "        " << "\t" << " for folders minimum permissions is 700." << endl;
-        os << "        " << "\t" << " Further restrictions to owner are not allowed (to avoid missfunctioning)." << endl;
+        os << "        " << "\t" << " Further restrictions to owner are not allowed (to avoid misfunctioning)." << endl;
         os << "        " << "\t" << " Notice that permissions of already existing files/folders will not change." << endl;
         os << "        " << "\t" << " Notice that permissions of already existing files/folders will not change." << endl;
         os << endl;


### PR DESCRIPTION
Hello 👋 ! I recently installed `megacmd` in my system through my package (`sudo dnf install megacmd`) manager and noticed a few typos in the help string of the command `permissions` (`permission --help`).

Thanks for reading and hope the changes are useful!