### PR TITLE
Fix build on BSDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,12 +461,14 @@ elseif(NOT WIN32)
         DESTINATION "etc/bash_completion.d"
         )
 
-    # generate 100-megacmd-inotify-limit.conf file and have it installed
-    execute_process(COMMAND echo "fs.inotify.max_user_watches = 524288"
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # generate 100-megacmd-inotify-limit.conf file and have it installed
+        execute_process(COMMAND echo "fs.inotify.max_user_watches = 524288"
                 OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/99-megacmd-inotify-limit.conf)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/99-megacmd-inotify-limit.conf
-        DESTINATION "etc/sysctl.d"
-        )
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/99-megacmd-inotify-limit.conf
+            DESTINATION "etc/sysctl.d"
+            )
+    endif()
 
     #Install vcpkg dynamic libraries in locations defined by GNUInstallDirs.
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/megacmdcommonutils.cpp
+++ b/src/megacmdcommonutils.cpp
@@ -1153,7 +1153,8 @@ bool isValidEmail(string email)
                     || (email.find("@") > email.find_last_of(".")));
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
+    defined(__NetBSD__) || defined(__DragonFly__)
 std::string getCurrentExecPath()
 {
     std::string path = ".";

--- a/src/megacmdcommonutils.h
+++ b/src/megacmdcommonutils.h
@@ -318,7 +318,8 @@ void sleepMilliSeconds(long microseconds);
 
 bool isValidEmail(std::string email);
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
+    defined(__NetBSD__) || defined(__DragonFly__)
 std::string getCurrentExecPath();
 #endif
 

--- a/src/megacmdshell/megacmdshellcommunications.cpp
+++ b/src/megacmdshell/megacmdshellcommunications.cpp
@@ -44,7 +44,7 @@
 #include <limits.h>
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 #include <netinet/in.h>
 #endif
 


### PR DESCRIPTION
Following https://github.com/meganz/sdk/issues/2661, I added changes to fix megacmd build on BSDs.