### PR TITLE
Fix spelling errors in the codebase

### DIFF
--- a/src/configurationmanager.cpp
+++ b/src/configurationmanager.cpp
@@ -483,7 +483,7 @@ void ConfigurationManager::transitionLegacyExclusionRules(MegaApi& api)
     // This ensures transition works in case there are no existing syncs
     megaIgnoreFile.addFilters(excludeFilters);
 
-    LOG_debug << "Transition of legacy exclusion rules completed successfully. Hidding legacy exclude file";
+    LOG_debug << "Transition of legacy exclusion rules completed successfully. Hiding legacy exclude file";
     try
     {
         fs::rename(excludeFilePath, hiddenExcludeFilePath);

--- a/src/megacmd.cpp
+++ b/src/megacmd.cpp
@@ -2092,7 +2092,7 @@ bool validCommand(string thecommand)
 string getsupportedregexps()
 {
 #ifdef USE_PCRE
-        return "Perl Compatible Regular Expressions with \"--use-pcre\"\n   or wildcarded expresions with ? or * like f*00?.txt";
+        return "Perl Compatible Regular Expressions with \"--use-pcre\"\n   or wildcarded expressions with ? or * like f*00?.txt";
 #elif __cplusplus >= 201103L
         return "c++11 Regular Expressions";
 #else
@@ -2146,7 +2146,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
               "write privileges. Without this option, you will log into the link with read access only." << endl;
         os << "\t--resume: A convenience option to try to resume from cache. When login into a folder, contrary to what occurs with login into a user account,"
               " MEGAcmd will not try to load anything from cache: loading everything from scratch. This option changes that. Note, "
-              "login using a session string, will of course, try to load from cache. This option may be convinient, for instance, if you previously "
+              "login using a session string, will of course, try to load from cache. This option may be convenient, for instance, if you previously "
               "logged out using --keep-session." << endl;
         os << endl;
         os << "For more information about MEGA folder links, see \"" << getCommandPrefixBasedOnMode() << "export --help\"." << endl;
@@ -2277,7 +2277,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
         os << "   " << "\t" << "     xxxx" << endl;
         os << "   " << "\t" << "     |||+---- Sharing status: (s)hared, (i)n share or not shared(-)" << endl;
         os << "   " << "\t" << "     ||+----- if exported, whether it is (p)ermanent or (t)temporal" << endl;
-        os << "   " << "\t" << "     |+------ e/- wheter node is (e)xported" << endl;
+        os << "   " << "\t" << "     |+------ e/- whether node is (e)xported" << endl;
         os << "   " << "\t" << "     +-------- Type(d=folder,-=file,r=root,i=inbox,b=rubbish,x=unsupported)" << endl;
         os << "   " << "\t" << "   VERS: Number of versions in a file" << endl;
         os << "   " << "\t" << "   SIZE: Size of the file in bytes:" << endl;
@@ -2539,7 +2539,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
     {
         os << "Shows if HTTPS is used for transfers. Use \"https on\" to enable it." << endl;
         os << endl;
-        os << "HTTPS is not necesary since all data is stored and transfered encrypted." << endl;
+        os << "HTTPS is not necessary since all data is stored and transferred encrypted." << endl;
         os << "Enabling it will increase CPU usage and add network overhead." << endl;
         os << endl;
         os << "Notice that this setting will be saved for the next time you open MEGAcmd, but will be removed if you logout." << endl;
@@ -2579,8 +2579,8 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
         os << " --public   " << "\t" << "*Allow access from outside localhost" << endl;
         os << " --port=PORT" << "\t" << "*Port to serve. DEFAULT= 4443" << endl;
         os << " --tls      " << "\t" << "*Serve with TLS (HTTPS)" << endl;
-        os << " --certificate=/path/to/certificate.pem" << "\t" << "*Path to PEM formated certificate" << endl;
-        os << " --key=/path/to/certificate.key" << "\t" << "*Path to PEM formated key" << endl;
+        os << " --certificate=/path/to/certificate.pem" << "\t" << "*Path to PEM formatted certificate" << endl;
+        os << " --key=/path/to/certificate.key" << "\t" << "*Path to PEM formatted key" << endl;
 
         if (flags.usePcre || flags.showAll)
         {
@@ -2609,8 +2609,8 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
         os << " --port=PORT" << "\t" << "*Port to serve. DEFAULT=4990" << endl;
         os << " --data-ports=BEGIN-END" << "\t" << "*Ports range used for data channel (in passive mode). DEFAULT=1500-1600" << endl;
         os << " --tls      " << "\t" << "*Serve with TLS (FTPs)" << endl;
-        os << " --certificate=/path/to/certificate.pem" << "\t" << "*Path to PEM formated certificate" << endl;
-        os << " --key=/path/to/certificate.key" << "\t" << "*Path to PEM formated key" << endl;
+        os << " --certificate=/path/to/certificate.pem" << "\t" << "*Path to PEM formatted certificate" << endl;
+        os << " --key=/path/to/certificate.key" << "\t" << "*Path to PEM formatted key" << endl;
 
         if (flags.usePcre || flags.showAll)
         {
@@ -2814,7 +2814,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
         os << "  \t"  << "  will be carried out nevertheless." << endl;
         os << "  \t"  << "If MEGAcmd server is not running when a backup is scheduled and the time for the next one has already arrived," << endl;
         os << "  \t"  << " an empty BACKUP will be created with state SKIPPED" << endl;
-        os << "  \t"  << "If a backup(1) is ONGOING and the time for the next backup(2) arrives, it won't start untill the previous one(1)" << endl;
+        os << "  \t"  << "If a backup(1) is ONGOING and the time for the next backup(2) arrives, it won't start until the previous one(1)" << endl;
         os << "  \t"  << " is completed, and if by the time the first one(1) ends the time for the next one(3) has already arrived," << endl;
         os << "  \t"  << " an empty BACKUP(2) will be created with state SKIPPED" << endl;
         os << " --path-display-size=N" << "\t" << "Use a fixed size of N characters for paths" << endl;
@@ -2841,8 +2841,8 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
         os << "                       \t" << "   e.g. \"1m12d3h\" indicates 1 month, 12 days and 3 hours" << endl;
         os << "                       \t" << "  Notice that this is an uncertain measure since not all months" << endl;
         os << "                       \t" << "  last the same and Daylight saving time changes are not considered" << endl;
-        os << "                       \t" << "  If possible use a cron like expresion" << endl;
-        os << "                       \t" << "Notice: regardless of the period expresion, the first time you establish a backup," << endl;
+        os << "                       \t" << "  If possible use a cron like expression" << endl;
+        os << "                       \t" << "Notice: regardless of the period expression, the first time you establish a backup," << endl;
         os << "                       \t" << " it will be created immediately" << endl;
         os << "--num-backups=N\t" << "Maximum number of backups to store" << endl;
         os << "                 \t" << " After creating the backup (N+1) the oldest one will be deleted" << endl;
@@ -2919,7 +2919,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
         os << " --with=email" << "\t" << "Determines the email of the user to [no longer] share with" << endl;
         os << " -d" << "\t" << "Stop sharing with the selected user" << endl;
         os << " -a" << "\t" << "Adds a share (or modifies it if existing)" << endl;
-        os << " --level=LEVEL" << "\t" << "Level of acces given to the user" << endl;
+        os << " --level=LEVEL" << "\t" << "Level of access given to the user" << endl;
         os << "              " << "\t" << "0: " << "Read access" << endl;
         os << "              " << "\t" << "1: " << "Read and write" << endl;
         os << "              " << "\t" << "2: " << "Full access" << endl;
@@ -3192,7 +3192,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
     {
         os << "List or operate with transfers" << endl;
         os << endl;
-        os << "If executed without option it will list the first 10 tranfers" << endl;
+        os << "If executed without option it will list the first 10 transfers" << endl;
         os << "Options:" << endl;
         os << " -c (TAG|-a)" << "\t" << "Cancel transfer with TAG (or all with -a)" << endl;
         os << " -p (TAG|-a)" << "\t" << "Pause transfer with TAG (or all with -a)" << endl;
@@ -3230,7 +3230,7 @@ string getHelpStr(const char *command, const HelpFlags& flags = {})
     }
     else if (((flags.win && !flags.readline) || flags.showAll) && !strcmp(command, "autocomplete"))
     {
-        os << "Modifes how tab completion operates." << endl;
+        os << "Modifies how tab completion operates." << endl;
         os << endl;
         os << "The default is to operate like the native platform. However" << endl;
         os << "you can switch it between mode 'dos' and 'unix' as you prefer." << endl;
@@ -4053,7 +4053,7 @@ void MegaCmdExecuter::mayExecutePendingStuffInWorkerThread()
             static HammeringLimiter hammeringLimiter(10);
             if (!hammeringLimiter.runRecently())
             {
-                LOG_err << "Invalid utf8 accumulated occurences: " << incidencesFound;
+                LOG_err << "Invalid utf8 accumulated occurrences: " << incidencesFound;
                 sendEvent(StatsManager::MegacmdEvent::INVALID_UTF8_INCIDENCES, api, false);
             }
             else
@@ -4273,7 +4273,7 @@ void* doProcessLine(void* infRaw)
         LOG_verbose << " Exit registered upon process_line: " ;
     }
 
-    LOG_verbose << " Procesed " << inf->getRedactedLine() << " in thread: " << MegaThread::currentThreadId() << " " << inf->getPetitionDetails();
+    LOG_verbose << " Processed " << inf->getRedactedLine() << " in thread: " << MegaThread::currentThreadId() << " " << inf->getPetitionDetails();
 
     MegaThread * petitionThread = inf->getPetitionThread();
 

--- a/src/megacmd_fuse.cpp
+++ b/src/megacmd_fuse.cpp
@@ -20,7 +20,7 @@ std::string_view getDisclaimer()
     return "Disclaimer:\n"
            "    - Streaming is not supported; entire files need to be downloaded completely before being opened.\n"
            "    - FUSE uses a local cache located in the MEGAcmd configuration folder. Make sure you have enough available space "
-           "in your hard drive to accomodate new files. Restarting MEGAcmd server can help discard old files.\n"
+           "in your hard drive to accommodate new files. Restarting MEGAcmd server can help discard old files.\n"
            "    - File writes might be deferred. When files are updated in the local mount point, a transfer will be initiated. "
            "Your files will be available in MEGA only after pending transfers finish.";
 }
@@ -339,7 +339,7 @@ void printAllMounts(mega::MegaApi& api, ColumnDisplayer& cd, bool onlyEnabled, b
     std::unique_ptr<MegaMountList> mounts(api.listMounts(onlyEnabled));
     if (mounts == nullptr)
     {
-        LOG_err << "Failed to retreive the list of mounts";
+        LOG_err << "Failed to retrieve the list of mounts";
         return;
     }
 

--- a/src/megacmdexecuter.cpp
+++ b/src/megacmdexecuter.cpp
@@ -2232,7 +2232,7 @@ void MegaCmdExecuter::changePassword(const char *newpassword, string pin2fa)
         }
         else if (checkNoErrors(megaCmdListener2->getError(), "change password with auth code"))
         {
-            OUTSTREAM << "Password changed succesfully" << endl;
+            OUTSTREAM << "Password changed successfully" << endl;
         }
 
     }
@@ -2242,7 +2242,7 @@ void MegaCmdExecuter::changePassword(const char *newpassword, string pin2fa)
     }
     else
     {
-        OUTSTREAM << "Password changed succesfully" << endl;
+        OUTSTREAM << "Password changed successfully" << endl;
     }
     delete megaCmdListener;
 }
@@ -2494,7 +2494,7 @@ bool MegaCmdExecuter::actUponFetchNodes(MegaApi *api, SynchronousRequestListener
 
     if (srl->getError()->getErrorCode() == MegaError::API_EBLOCKED)
     {
-        LOG_verbose << " EBLOCKED after fetch nodes. quering for reason...";
+        LOG_verbose << " EBLOCKED after fetch nodes. querying for reason...";
 
         MegaCmdListener *megaCmdListener = new MegaCmdListener(api, NULL);
         api->whyAmIBlocked(megaCmdListener); //This shall cause event that sets reasonblocked
@@ -2826,7 +2826,7 @@ void MegaCmdExecuter::fetchNodes(MegaApi *api, int clientID)
             {
                 thebackup->failed = false;
                 const char *nodepath = api->getNodePath(node);
-                LOG_debug << "Succesfully resumed backup: " << thebackup->localpath << " to " << nodepath;
+                LOG_debug << "Successfully resumed backup: " << thebackup->localpath << " to " << nodepath;
                 delete []nodepath;
             }
             else
@@ -3289,7 +3289,7 @@ void MegaCmdExecuter::downloadNode(string source, string path, MegaApi* api, Meg
         // in order to speedup and not flood the server we only ask for the details every 1 minute or after account changes
         if (!sandboxCMD->temporalbandwidth || (ts - sandboxCMD->lastQuerytemporalBandwith ) > 60 )
         {
-            LOG_verbose << " Updating temporal bandwith ";
+            LOG_verbose << " Updating temporal bandwidth ";
             sandboxCMD->lastQuerytemporalBandwith = ts;
 
             MegaCmdListener *megaCmdListener = new MegaCmdListener(api, NULL);
@@ -3318,7 +3318,7 @@ void MegaCmdExecuter::downloadNode(string source, string path, MegaApi* api, Meg
         }
         else
         {
-            OUTSTREAM << "You have reached your bandwith quota";
+            OUTSTREAM << "You have reached your bandwidth quota";
         }
         OUTSTREAM << ". To circumvent this limit, "
                   "you can upgrade to Pro, which will give you your own bandwidth "
@@ -3338,7 +3338,7 @@ void MegaCmdExecuter::downloadNode(string source, string path, MegaApi* api, Meg
         {
             if (megaCmdListener->getRequest() && megaCmdListener->getRequest()->getFlag() )
             {
-                OUTSTREAM << "Transfer not started: proceding will exceed transfer quota. "
+                OUTSTREAM << "Transfer not started: proceeding will exceed transfer quota. "
                              "Use --ignore-quota-warn to initiate nevertheless" << endl;
                 return;
             }
@@ -4206,7 +4206,7 @@ void MegaCmdExecuter::signup(string name, string passwd, string email)
     megaCmdListener->wait();
     if (checkNoErrors(megaCmdListener->getError(), "create account <" + email + ">"))
     {
-        OUTSTREAM << "Account <" << email << "> created succesfully. You will receive a confirmation link. Use \"confirm\" with the provided link to confirm that account" << endl;
+        OUTSTREAM << "Account <" << email << "> created successfully. You will receive a confirmation link. Use \"confirm\" with the provided link to confirm that account" << endl;
     }
 
     delete megaCmdListener;
@@ -4234,7 +4234,7 @@ void MegaCmdExecuter::confirm(string passwd, string email, string link)
     }
     else if (checkNoErrors(megaCmdListener2->getError(), "confirm account"))
     {
-        OUTSTREAM << "Account " << email << " confirmed succesfully. You can login with it now" << endl;
+        OUTSTREAM << "Account " << email << " confirmed successfully. You can login with it now" << endl;
     }
 
     delete megaCmdListener2;
@@ -4692,7 +4692,7 @@ void MegaCmdExecuter::printBackup(backup_struct *backupstruct, const char *timeF
     }
     else
     { //merely print configuration
-        printBackupSummary(backupstruct->tag, backupstruct->localpath.c_str(),"UNKOWN"," FAILED", PATHSIZE);
+        printBackupSummary(backupstruct->tag, backupstruct->localpath.c_str(),"UNKNOWN"," FAILED", PATHSIZE);
         if (extendedinfo)
         {
             string speriod = (backupstruct->period == -1)?backupstruct->speriod:getReadablePeriod(backupstruct->period/10);
@@ -5182,7 +5182,7 @@ void MegaCmdExecuter::confirmCancel(const char* confirmlink, const char* pass)
     else if (megaCmdListener->getError()->getErrorCode() == MegaError::API_ESID ||
              checkNoErrors(megaCmdListener->getError(), "confirm cancel account"))
     {
-        OUTSTREAM << "CONFIRM Account cancelled succesfully" << endl;
+        OUTSTREAM << "CONFIRM Account cancelled successfully" << endl;
 
         megaCmdListener = std::make_unique<MegaCmdListener>(nullptr);
         api->localLogout(megaCmdListener.get());
@@ -7414,7 +7414,7 @@ void MegaCmdExecuter::executecommand(vector<string> words, map<string, int> *clf
                 megaCmdListener->wait();
                 if (checkNoErrors(megaCmdListener->getError(), "remove all versions"))
                 {
-                    OUTSTREAM << "File versions deleted succesfully. Please note that the current files were not deleted, just their history." << endl;
+                    OUTSTREAM << "File versions deleted successfully. Please note that the current files were not deleted, just their history." << endl;
                 }
                 delete megaCmdListener;
             }
@@ -8613,7 +8613,7 @@ void MegaCmdExecuter::executecommand(vector<string> words, map<string, int> *clf
                     megaCmdListener->wait();
                     if (checkNoErrors(megaCmdListener->getError(), "delete contact"))
                     {
-                        OUTSTREAM << "Contact " << words[1] << " removed succesfully" << endl;
+                        OUTSTREAM << "Contact " << words[1] << " removed successfully" << endl;
                     }
                     delete megaCmdListener;
                 }
@@ -10087,7 +10087,7 @@ void MegaCmdExecuter::executecommand(vector<string> words, map<string, int> *clf
             {
                 if (megaCmdListener->getRequest()->getFlag())
                 {
-                    OUTSTREAM << "Account " << email << " confirmed succesfully. You can login with it now" << endl;
+                    OUTSTREAM << "Account " << email << " confirmed successfully. You can login with it now" << endl;
                 }
                 else if (megaCmdListener->getRequest()->getEmail() && email == megaCmdListener->getRequest()->getEmail())
                 {
@@ -10481,7 +10481,7 @@ void MegaCmdExecuter::executecommand(vector<string> words, map<string, int> *clf
                     }
                     else
                     {
-                        LOG_err << "Coul not find transfer with tag: " << words[i];
+                        LOG_err << "Could not find transfer with tag: " << words[i];
                         setCurrentThreadOutCode(MCMD_NOTFOUND);
                     }
                 }
@@ -10550,7 +10550,7 @@ void MegaCmdExecuter::executecommand(vector<string> words, map<string, int> *clf
                     }
                     else
                     {
-                        LOG_err << "Coul not find transfer with tag: " << words[i];
+                        LOG_err << "Could not find transfer with tag: " << words[i];
                         setCurrentThreadOutCode(MCMD_NOTFOUND);
                     }
                 }

--- a/src/megacmdutils.cpp
+++ b/src/megacmdutils.cpp
@@ -129,7 +129,7 @@ string visibilityToString(int visibility)
     }
     if (visibility == MegaUser::VISIBILITY_UNKNOWN)
     {
-        return "Unkown visibility";
+        return "Unknown visibility";
     }
     if (visibility == MegaUser::VISIBILITY_INACTIVE)
     {


### PR DESCRIPTION
Hi!
I'm packaging megacmd for Debian, and I found some spelling errors 
and decided to contribute these corrections to the project.
Hope this helps!