### PR TITLE
Fix missing FileSystemAccess implementation and header includes

### DIFF
--- a/src/megacmdexecuter.cpp
+++ b/src/megacmdexecuter.cpp
@@ -38,6 +38,8 @@
 #include <set>
 
 #include <signal.h>
+#include <mega/localpath.h>
+#include <mega/posix/megafs.h>
 
 #ifdef MEGACMD_TESTING_CODE
     #include "../tests/common/Instruments.h"
@@ -129,6 +131,13 @@ std::optional<FuseCommand::ConfigDelta> loadFuseConfigDelta(const std::map<std::
     return configDelta;
 }
 #endif
+
+class MegaFileSystemAccess : public mega::PosixFileSystemAccess {
+public:
+    void addevents(mega::Waiter*, int) override {
+        // Implementation dummy
+    }
+};
 
 /**
  * @brief updateprompt updates prompt with the current user/location

--- a/src/megacmdexecuter.h
+++ b/src/megacmdexecuter.h
@@ -36,7 +36,7 @@ private:
     mega::MegaApi *api;
     mega::handle cwd;
     std::unique_ptr<char[]> session;
-    mega::MegaFileSystemAccess *fsAccessCMD;
+    mega::FileSystemAccess *fsAccessCMD;
     MegaCmdLogger *loggerCMD;
     MegaCmdSandbox *sandboxCMD;
     MegaCmdGlobalTransferListener *globalTransferListener;


### PR DESCRIPTION
Hi!
his patch adds missing includes (<mega/localpath.h> and <mega/posix/megafs.h>)
and defines a dummy MegaFileSystemAccess class to resolve build errors when
compiling MegaCMD against the latest SDK.

These changes ensure compatibility with the updated LocalPath interface and
enable successful compilation without requiring SDK-side modifications.

I need to do this to fix compilation errors in the Debian environment. If you contribute to megacmd, feel free to incorporate it into megacmd if you wish.

